### PR TITLE
[Debug] avoid signal macro clashes in GDB stub

### DIFF
--- a/src/xenia/debug/gdb/gdbstub.cc
+++ b/src/xenia/debug/gdb/gdbstub.cc
@@ -239,13 +239,13 @@ void GDBStub::Listen(GDBClient& client) {
             cache_.cur_thread_id = cache_.notify_thread_id;
           }
 
-          SignalCode signal = SignalCode::SIGTRAP;
+          SignalCode signal = SignalCode::kSIGTRAP;
           if (cache_.notify_exception_code.has_value()) {
             if (cache_.notify_exception_code ==
                 xe::Exception::Code::kIllegalInstruction) {
-              signal = SignalCode::SIGILL;
+              signal = SignalCode::kSIGILL;
             } else {
-              signal = SignalCode::SIGSEGV;
+              signal = SignalCode::kSIGSEGV;
             }
 
             cache_.notify_exception_code.reset();

--- a/src/xenia/debug/gdb/gdbstub.h
+++ b/src/xenia/debug/gdb/gdbstub.h
@@ -35,7 +35,7 @@ class GDBStub : public cpu::DebugListener {
     Interrupt = '\03',
   };
 
-  enum class SignalCode : uint8_t { SIGILL = 4, SIGTRAP = 5, SIGSEGV = 11 };
+  enum class SignalCode : uint8_t { kSIGILL = 4, kSIGTRAP = 5, kSIGSEGV = 11 };
 
   enum class RegisterIndex : int {
     GPR0 = 0,


### PR DESCRIPTION
## Summary
- Fix GDB stub signal macro clashes.

## Dependencies / Merge Order
Merge order: 7/7
Depends on: None