### PR TITLE
[ThirdParty] fix sha256 endian handling on Apple

### DIFF
--- a/third_party/crypto/sha256.cpp
+++ b/third_party/crypto/sha256.cpp
@@ -9,7 +9,15 @@
 
 // big endian architectures need #define __BYTE_ORDER __BIG_ENDIAN
 #ifndef _MSC_VER
+#if defined(__APPLE__)
+#if !defined(__BYTE_ORDER) && defined(__BYTE_ORDER__) && \
+    defined(__ORDER_BIG_ENDIAN__)
+#define __BYTE_ORDER __BYTE_ORDER__
+#define __BIG_ENDIAN __ORDER_BIG_ENDIAN__
+#endif
+#else
 #include <endian.h>
+#endif
 #endif
 
 namespace sha256 {


### PR DESCRIPTION
## Summary
- Fix SHA256 endian handling on Apple platforms (no `<endian.h>`).
Depends on: None