### PR TITLE
[Build] Normalize platform variants and CI/macOS build plumbing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,13 +65,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-linuxdeploy-
 
-      - name: Cache submodules
-        id: cache-submodules
-        uses: actions/cache@v3
-        with:
-          path: third_party
-          key: ${{ runner.os }}-submodules-${{ hashFiles('.gitmodules') }}-${{ hashFiles('.git/modules/third_party/*/HEAD') }}
-
       - name: Cache Vulkan SDK
         id: cache-vulkan-sdk-linux
         uses: actions/cache@v3
@@ -129,10 +122,10 @@ jobs:
           which spirv-opt && spirv-opt --version || echo "Warning: spirv-opt not found"
           which spirv-dis || echo "Warning: spirv-dis not found"
 
-          # Update submodules if not cached
-          if [ '${{ steps.cache-submodules.outputs.cache-hit }}' != 'true' ]; then
-            git submodule update --init --depth=1 -j$(getconf _NPROCESSORS_ONLN) $(grep -oP '(?<=path = )(?!third_party\/(DirectXShaderCompiler|premake-(androidndk|export-compile-commands))).+' .gitmodules)
-          fi
+          # Always refresh submodules: cached third_party content can be stale
+          # without corresponding .git/modules metadata.
+          git submodule sync --recursive
+          git submodule update --init --force --depth=1 -j$(getconf _NPROCESSORS_ONLN) $(grep -oP '(?<=path = )(?!third_party\/(DirectXShaderCompiler|premake-(androidndk|export-compile-commands))).+' .gitmodules)
 
           if [ '${{ steps.cache-premake5.outputs.cache-hit }}' != 'true' ]; then
             ./xenia-build.py premake
@@ -149,7 +142,7 @@ jobs:
       - name: Prepare artifacts
         id: prepare_artifacts
         run: |
-          binary=build/bin/Linux/Release/xenia_edge
+          binary=build/bin/Linux-x86_64/Release/xenia_edge
           if [ $(stat -c%s $binary) -le 100000 ]; then
             echo "::error::Binary is too small."
           fi
@@ -182,7 +175,7 @@ jobs:
           # Copy all necessary files (excluding build artifacts) next to the binary in AppDir
           mkdir -p artifacts/xenia_edge/usr/bin
           # Copy directories (optimized_settings, game_patches, etc.)
-          find build/bin/Linux/Release -maxdepth 1 -type d ! -name Release -exec cp -r {} artifacts/xenia_edge/usr/bin/ \;
+          find build/bin/Linux-x86_64/Release -maxdepth 1 -type d ! -name Release -exec cp -r {} artifacts/xenia_edge/usr/bin/ \;
           # Copy any additional runtime files if needed (currently just directories are copied)
 
           # Run linuxdeploy with Qt plugin to deploy all Qt dependencies and create AppImage
@@ -247,13 +240,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-qt6-
 
-      - name: Cache submodules
-        id: cache-submodules
-        uses: actions/cache@v3
-        with:
-          path: third_party
-          key: ${{ runner.os }}-submodules-${{ hashFiles('.gitmodules') }}-${{ hashFiles('.git/modules/third_party/*/HEAD') }}
-
       - name: Setup
         run: |
           # Install Vulkan SDK which includes spirv-tools
@@ -308,10 +294,8 @@ jobs:
             aqt install-qt windows desktop 6.10.1 win64_msvc2022_64 -O C:\Qt
           }
 
-          $cacheHit = '${{ steps.cache-submodules.outputs.cache-hit }}'
-          if ($cacheHit -ne 'true') {
-            git submodule update --init --depth=1 -j $env:NUMBER_OF_PROCESSORS (Select-String -CaseSensitive '(?<=path = )(?!third_party\/(premake-(androidndk|cmake|export-compile-commands))).+' .gitmodules).Matches.Value
-          }
+          git submodule sync --recursive
+          git submodule update --init --force --depth=1 -j $env:NUMBER_OF_PROCESSORS (Select-String -CaseSensitive '(?<=path = )(?!third_party\/(premake-(androidndk|cmake|export-compile-commands))).+' .gitmodules).Matches.Value
 
           # Fetch data repos (game-patches, optimized-settings)
           python xenia-build.py fetchdata
@@ -321,13 +305,13 @@ jobs:
       - name: Prepare artifacts
         id: prepare_artifacts
         run: |
-          $binary = 'build\bin\Windows\Release\xenia_edge.exe'
+          $binary = 'build\bin\Windows-x86_64\Release\xenia_edge.exe'
           if ((get-item $binary).Length -le 100000) {
             echo "::error::$binary is too small."
           }
-          robocopy . build\bin\Windows\Release LICENSE /r:0 /w:0
+          robocopy . build\bin\Windows-x86_64\Release LICENSE /r:0 /w:0
           # Copy all files and directories (Qt DLLs, plugins, etc.) excluding build artifacts
-          robocopy build\bin\Windows\Release artifacts\xenia_edge /MIR /r:0 /w:0 /XF *.lib *.idb *.exp /XD generic iconengines imageformats networkinformation styles tls
+          robocopy build\bin\Windows-x86_64\Release artifacts\xenia_edge /MIR /r:0 /w:0 /XF *.lib *.idb *.exp /XD generic iconengines imageformats networkinformation styles tls
           If ($LastExitCode -le 7) { echo "LastExitCode = $LastExitCode";$LastExitCode = 0 }
       - name: Upload xenia edge artifacts
         if: steps.prepare_artifacts.outcome == 'success'

--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,10 @@ src/xenia/ui/moc_*.cc
 
 # Generated shader bytecode
 src/xenia/gpu/shaders/bytecode/d3d12_5_1/
+src/xenia/gpu/shaders/bytecode/metal/
 src/xenia/gpu/shaders/bytecode/vulkan_spirv/
 src/xenia/ui/shaders/bytecode/d3d12_5_1/
+src/xenia/ui/shaders/bytecode/metal/
 src/xenia/ui/shaders/bytecode/vulkan_spirv/
 
 # ==============================================================================

--- a/premake5.lua
+++ b/premake5.lua
@@ -11,8 +11,27 @@ end
 
 -- Helper function to extract Qt version from qconfig.pri
 function get_qt_version(qt_dir)
+  -- Try standard location first
   local qconfig_path = path.join(qt_dir, "mkspecs/qconfig.pri")
   local qconfig_file = io.open(qconfig_path, "r")
+
+  -- Try system Qt location (e.g., /usr/lib/x86_64-linux-gnu/qt6)
+  if not qconfig_file then
+    -- For system Qt, qt_dir might be cmake path - try to find actual Qt dir
+    local system_paths = {
+      "/usr/lib/x86_64-linux-gnu/qt6/mkspecs/qconfig.pri",
+      "/usr/lib/aarch64-linux-gnu/qt6/mkspecs/qconfig.pri",
+      "/usr/share/qt6/mkspecs/qconfig.pri",
+    }
+    for _, sys_path in ipairs(system_paths) do
+      qconfig_file = io.open(sys_path, "r")
+      if qconfig_file then
+        qconfig_path = sys_path
+        break
+      end
+    end
+  end
+
   if qconfig_file then
     for line in qconfig_file:lines() do
       local version = line:match("^QT_VERSION%s*=%s*(.+)$")
@@ -23,7 +42,9 @@ function get_qt_version(qt_dir)
     end
     qconfig_file:close()
   end
-  error("Could not read Qt version from " .. qconfig_path)
+
+  -- Return nil instead of error for system Qt without qconfig.pri
+  return nil
 end
 
 location(build_root)
@@ -31,8 +52,21 @@ targetdir(build_bin)
 objdir(build_obj)
 
 -- Define variables for enabling specific submodules
--- Todo: Add changing from xb command
-enableTests = false
+newoption({
+  trigger = "tests",
+  description = "Enable building test targets",
+})
+newoption({
+  trigger = "mac-x86_64",
+  description = "Enable x86_64 platform on macOS ARM64 hosts",
+})
+newoption({
+  trigger = "arch",
+  value = "ARCH",
+  description = "Target architecture (x86_64 or arm64)",
+})
+
+enableTests = _OPTIONS["tests"] ~= nil
 enableMiscSubprojects = false
 
 -- Define an ARCH variable
@@ -43,11 +77,95 @@ else
   ARCH = "unknown"
 end
 
+function is_macos_arm64_host()
+  local env = os.getenv("XE_MACOS_ARM64_HOST")
+  if env == "1" then
+    return true
+  end
+  if env == "0" then
+    return false
+  end
+  if not os.istarget("macosx") then
+    return false
+  end
+  local sysctl = os.outputof("sysctl -n hw.optional.arm64 2>/dev/null")
+  if sysctl then
+    local sysctl_value = sysctl:match("^(%d+)")
+    if sysctl_value == "1" then
+      return true
+    end
+  end
+  local machine = os.outputof("uname -m")
+  if machine then
+    local machine_value = machine:match("^(%S+)")
+    if machine_value == "arm64" then
+      return true
+    end
+  end
+  return false
+end
+
+local function normalize_arch(arch)
+  if not arch then
+    return nil
+  end
+  arch = arch:lower()
+  if arch == "arm64" or arch == "aarch64" then
+    return "ARM64"
+  end
+  if arch == "x86_64" or arch == "x64" or arch == "x86" or arch == "amd64" then
+    return "x86_64"
+  end
+  return nil
+end
+
+local function detect_target_arch()
+  local option_arch = normalize_arch(_OPTIONS["arch"])
+  if option_arch then
+    return option_arch
+  end
+  if os.istarget("macosx") then
+    if _OPTIONS["mac-x86_64"] then
+      return "x86_64"
+    end
+    return is_macos_arm64_host() and "ARM64" or "x86_64"
+  end
+  if os.istarget("linux") then
+    return normalize_arch(os.outputof("uname -m")) or "x86_64"
+  end
+  if os.istarget("windows") then
+    local env_arch = os.getenv("PROCESSOR_ARCHITEW6432") or
+                     os.getenv("PROCESSOR_ARCHITECTURE")
+    return normalize_arch(env_arch) or "x86_64"
+  end
+  return "x86_64"
+end
+
+TARGET_ARCH = detect_target_arch()
+
 includedirs({
   ".",
   "src",
   "third_party",
 })
+
+-- Add SDL2 include path for Linux cmake builds
+-- premake-cmake doesn't properly handle includedirs from sdl2_include() function
+if os.istarget("linux") then
+  local sdl2_config = os.getenv("SDL2_CONFIG") or "sdl2-config"
+  local sdl2_cflags = os.outputof(sdl2_config .. " --cflags")
+  if sdl2_cflags then
+    for inc in string.gmatch(sdl2_cflags, "-I([%S]+)") do
+      includedirs({inc})
+      print("SDL2: Global include dir: " .. inc)
+    end
+  end
+  -- Fallback to common location if sdl2-config doesn't return -I flags
+  if not sdl2_cflags or not string.find(sdl2_cflags, "-I") then
+    includedirs({"/usr/include/SDL2"})
+    print("SDL2: Using fallback global include /usr/include/SDL2")
+  end
+end
 
 defines({
   "VULKAN_HPP_NO_TO_STRING",
@@ -92,7 +210,7 @@ filter("configurations:Checked")
     "NDEBUG",
   })
 
-filter({"configurations:Checked", "platforms:Linux"})
+filter({"configurations:Checked", "platforms:Linux-*"})
   buildoptions({
     "-fsanitize=undefined",
   })
@@ -100,19 +218,19 @@ filter({"configurations:Checked", "platforms:Linux"})
     "-fsanitize=undefined",
   })
 
-filter({"configurations:Checked", "platforms:Windows"}) -- "toolset:msc"
+filter({"configurations:Checked", "platforms:Windows-*"}) -- "toolset:msc"
   buildoptions({
     "/RTCsu",           -- Full Run-Time Checks.
   })
   -- AddressSanitizer on Windows (doesn't conflict with memory layout like on Linux)
   sanitize("Address")
 
-filter({"configurations:Checked or Debug", "platforms:Linux"})
+filter({"configurations:Checked or Debug", "platforms:Linux-*"})
   defines({
     -- "_GLIBCXX_DEBUG",   -- libstdc++ debug mode (disabled - causes ABI issues with system libraries)
   })
 
-filter({"configurations:Checked or Debug", "platforms:Windows"}) -- "toolset:msc"
+filter({"configurations:Checked or Debug", "platforms:Windows-*"}) -- "toolset:msc"
   symbols("Full")
 
 filter("configurations:Debug")
@@ -142,7 +260,7 @@ filter("configurations:Release")
   -- (such as constant propagation) emulation as predictable as possible,
   -- including handling of specials since games make assumptions about them.
 
-filter({"configurations:Release", "platforms:not Windows"})
+filter({"configurations:Release", "platforms:Linux-* or Mac-* or Android-*"})
   symbols("On")  -- Enable debug symbols for crash debugging
   linktimeoptimization("On")
   buildoptions({
@@ -152,7 +270,7 @@ filter({"configurations:Release", "platforms:not Windows"})
     "-fomit-frame-pointer",  -- Don't keep frame pointer for better performance
   })
 
-filter({"configurations:Release", "platforms:Windows"}) -- "toolset:msc"
+filter({"configurations:Release", "platforms:Windows-*"}) -- "toolset:msc"
   symbols("Off")  -- Disable PDB generation for release builds
   linktimeoptimization("On")
   buildoptions({
@@ -177,64 +295,176 @@ filter("configurations:Valgrind")
     "-fno-inline-functions",    -- Disable function inlining for clearer traces
   })
 
-filter({"configurations:Valgrind", "platforms:Linux"})
+filter({"configurations:Valgrind", "platforms:Linux-*"})
   -- Additional Valgrind-friendly settings for Linux
   buildoptions({
     "-g3",  -- Maximum debug info
   })
 
-filter("platforms:Linux")
-  system("linux")
-  toolset("clang")
-  local qt_dir = os.getenv("QT_DIR")
-  if qt_dir then
-    local qt_version = get_qt_version(qt_dir)
-    includedirs({
-      path.join(qt_dir, "include"),
-      path.join(qt_dir, "include/QtCore"),
-      path.join(qt_dir, "include/QtCore", qt_version),
-      path.join(qt_dir, "include/QtCore", qt_version, "QtCore"),
-      path.join(qt_dir, "include/QtGui"),
-      path.join(qt_dir, "include/QtGui", qt_version),
-      path.join(qt_dir, "include/QtGui", qt_version, "QtGui"),
-      path.join(qt_dir, "include/QtWidgets"),
-    })
-    libdirs({
-      path.join(qt_dir, "lib"),
-    })
-    runpathdirs({
-      path.join(qt_dir, "lib"),
-    })
-    -- For CMake: set RPATH to find Qt libraries
-    linkoptions({
-      "-Wl,-rpath," .. path.join(qt_dir, "lib"),
-    })
+if os.istarget("linux") then
+  filter("platforms:Linux-*")
+    system("linux")
+    toolset("clang")
+    local qt_dir = os.getenv("QT_DIR")
+    if qt_dir then
+      local qt_version = get_qt_version(qt_dir)
+      if qt_version then
+        -- Qt installed via aqtinstall or similar (has version-specific dirs)
+        includedirs({
+          path.join(qt_dir, "include"),
+          path.join(qt_dir, "include/QtCore"),
+          path.join(qt_dir, "include/QtCore", qt_version),
+          path.join(qt_dir, "include/QtCore", qt_version, "QtCore"),
+          path.join(qt_dir, "include/QtGui"),
+          path.join(qt_dir, "include/QtGui", qt_version),
+          path.join(qt_dir, "include/QtGui", qt_version, "QtGui"),
+          path.join(qt_dir, "include/QtWidgets"),
+        })
+        libdirs({
+          path.join(qt_dir, "lib"),
+        })
+        runpathdirs({
+          path.join(qt_dir, "lib"),
+        })
+        linkoptions({
+          "-Wl,-rpath," .. path.join(qt_dir, "lib"),
+        })
+      else
+        -- QT_DIR set but no version found - assume it's a system path or cmake dir
+        -- Use standard system paths instead
+        includedirs({
+          "/usr/include/x86_64-linux-gnu/qt6",
+          "/usr/include/x86_64-linux-gnu/qt6/QtCore",
+          "/usr/include/x86_64-linux-gnu/qt6/QtGui",
+          "/usr/include/x86_64-linux-gnu/qt6/QtWidgets",
+          "/usr/include/aarch64-linux-gnu/qt6",
+          "/usr/include/aarch64-linux-gnu/qt6/QtCore",
+          "/usr/include/aarch64-linux-gnu/qt6/QtGui",
+          "/usr/include/aarch64-linux-gnu/qt6/QtWidgets",
+          "/usr/include/qt6",
+          "/usr/include/qt6/QtCore",
+          "/usr/include/qt6/QtGui",
+          "/usr/include/qt6/QtWidgets",
+        })
+      end
+    else
+      -- No QT_DIR set - use system Qt paths (installed via apt)
+      includedirs({
+        "/usr/include/x86_64-linux-gnu/qt6",
+        "/usr/include/x86_64-linux-gnu/qt6/QtCore",
+        "/usr/include/x86_64-linux-gnu/qt6/QtGui",
+        "/usr/include/x86_64-linux-gnu/qt6/QtWidgets",
+        "/usr/include/aarch64-linux-gnu/qt6",
+        "/usr/include/aarch64-linux-gnu/qt6/QtCore",
+        "/usr/include/aarch64-linux-gnu/qt6/QtGui",
+        "/usr/include/aarch64-linux-gnu/qt6/QtWidgets",
+        "/usr/include/qt6",
+        "/usr/include/qt6/QtCore",
+        "/usr/include/qt6/QtGui",
+        "/usr/include/qt6/QtWidgets",
+      })
+    end
+    -- Always link Qt on Linux
     links({
       "Qt6Core",
       "Qt6Gui",
       "Qt6Widgets",
     })
-  end
 
-  links({
-    "stdc++fs",
-    "dl",
-    "lz4",
-    "m",
-    "pthread",
-    "rt",
-  })
+    links({
+      "stdc++fs",
+      "dl",
+      "lz4",
+      "m",
+      "pthread",
+      "rt",
+    })
+end
 
-filter({"platforms:Linux", "kind:*App"})
+filter({"platforms:Linux-*", "kind:*App"})
   linkgroups("On")
 
-filter({"language:C++", "toolset:clang or gcc"}) -- "platforms:Linux"
+if os.istarget("macosx") then
+  filter("platforms:Mac-*")
+    buildoptions({
+      "-mmacosx-version-min=15.0",
+    })
+    linkoptions({
+      "-mmacosx-version-min=15.0",
+    })
+    xcodebuildsettings({
+      ["MACOSX_DEPLOYMENT_TARGET"] = "15.0",
+    })
+    local qt_dir = os.getenv("QT_DIR")
+    if not qt_dir then
+      local brew_prefix = os.outputof("brew --prefix qt@6 2>/dev/null")
+      if not brew_prefix or brew_prefix == "" then
+        brew_prefix = os.outputof("brew --prefix qt 2>/dev/null")
+      end
+      if brew_prefix then
+        brew_prefix = brew_prefix:gsub("%s+$", "")
+        if #brew_prefix > 0 and os.isdir(brew_prefix) then
+          qt_dir = brew_prefix
+        end
+      end
+    end
+    if not qt_dir then
+      local candidates = {
+        "/opt/homebrew/opt/qt",
+        "/opt/homebrew/opt/qt@6",
+        "/usr/local/opt/qt",
+        "/usr/local/opt/qt@6",
+      }
+      for _, candidate in ipairs(candidates) do
+        if os.isdir(candidate) then
+          qt_dir = candidate
+          break
+        end
+      end
+    end
+    if qt_dir then
+      frameworkdirs({
+        path.join(qt_dir, "lib"),
+      })
+      externalincludedirs({
+        path.join(qt_dir, "lib/QtCore.framework/Headers"),
+        path.join(qt_dir, "lib/QtGui.framework/Headers"),
+        path.join(qt_dir, "lib/QtWidgets.framework/Headers"),
+      })
+      buildoptions({
+        "-I" .. path.join(qt_dir, "lib/QtCore.framework/Headers"),
+        "-I" .. path.join(qt_dir, "lib/QtGui.framework/Headers"),
+        "-I" .. path.join(qt_dir, "lib/QtWidgets.framework/Headers"),
+      })
+      links({
+        "QtCore.framework",
+        "QtGui.framework",
+        "QtWidgets.framework",
+      })
+      linkoptions({
+        "-Wl,-rpath," .. path.join(qt_dir, "lib"),
+      })
+    end
+end
+
+filter({"platforms:Mac-*", "toolset:clang"})
+  buildoptions({
+    "-w",
+  })
+  removefatalwarnings("All")
+filter({"platforms:Mac-x86_64", "toolset:clang"})
+  buildoptions({
+    "-mavx",
+  })
+filter({})
+
+filter({"language:C++", "toolset:clang or gcc"}) -- "platforms:Linux-*"
   disablewarnings({
     "switch",
     "attributes",
   })
 
-filter({"language:C++", "toolset:gcc"}) -- "platforms:Linux"
+filter({"language:C++", "toolset:gcc"}) -- "platforms:Linux-*"
   disablewarnings({
     "unused-result",
     "volatile",
@@ -243,7 +473,7 @@ filter({"language:C++", "toolset:gcc"}) -- "platforms:Linux"
     "deprecated",
   })
 
-filter("toolset:gcc") -- "platforms:Linux"
+filter("toolset:gcc") -- "platforms:Linux-*"
   removefatalwarnings("All") -- HACK
   if ARCH == "ppc64" then
     buildoptions({
@@ -263,7 +493,7 @@ filter("toolset:gcc") -- "platforms:Linux"
     })
   end
 
-filter({"language:C++", "toolset:clang"}) -- "platforms:Linux"
+filter({"language:C++", "toolset:clang"}) -- "platforms:Linux-*"
   disablewarnings({
     "deprecated-register",
     "deprecated-volatile",
@@ -273,21 +503,33 @@ CLANG_BIN = os.getenv("CC") or _OPTIONS["cc"] or "clang"
 if os.istarget("linux") and string.contains(CLANG_BIN, "clang") then
   CLANG_VER = tonumber(string.match(os.outputof(CLANG_BIN.." --version"), "version (%d%d)"))
   if CLANG_VER >= 20 then
-    filter({"language:C++", "toolset:clang"}) -- "platforms:Linux"
+    filter({"language:C++", "toolset:clang"}) -- "platforms:Linux-*"
       disablewarnings({
         "deprecated-literal-operator",   -- Needed only for tabulate
         "nontrivial-memcall",
       })
   end
   if CLANG_VER >= 21 then
-    filter({"language:C++", "toolset:clang"}) -- "platforms:Linux"
+    filter({"language:C++", "toolset:clang"}) -- "platforms:Linux-*"
       disablewarnings({
         "character-conversion",          -- Needed for utfcpp third-party library
+        "absolute-value",                -- Needed for tomlplusplus third-party library
+        "enum-compare-switch",           -- Needed for a64_backend with capstone
+        "deprecated-enum-compare",       -- Needed for a64_backend with capstone
       })
   end
 end
+if os.istarget("linux") then
+  if ARCH == "aarch64" or ARCH == "arm64" then
+    filter({"platforms:Linux-*", "toolset:clang"})
+      buildoptions({
+        "-include arm_acle.h",
+      })
+  end
+end
+filter({})
 
-filter({"language:C", "toolset:clang or gcc"}) -- "platforms:Linux"
+filter({"language:C", "toolset:clang or gcc"}) -- "platforms:Linux-*"
   disablewarnings({
     "implicit-function-declaration",
   })
@@ -311,7 +553,7 @@ if os.istarget("android") then
     })
 end
 
-filter("platforms:Windows")
+filter("platforms:Windows-*")
   system("windows")
   toolset("msc")
   buildoptions({
@@ -331,7 +573,6 @@ filter("platforms:Windows")
     "_CRT_SECURE_NO_WARNINGS",
     "WIN32",
     "_WIN64=1",
-    "_AMD64=1",
   })
   linkoptions({
     "/ignore:4006",  -- Ignores complaints about empty obj files.
@@ -362,7 +603,17 @@ filter("platforms:Windows")
     })
   end
 
-filter({"platforms:Windows", "configurations:Release"})
+filter("platforms:Windows-x86_64")
+  defines({
+    "_AMD64=1",
+  })
+
+filter("platforms:Windows-ARM64")
+  defines({
+    "_ARM64_=1",
+  })
+
+filter({"platforms:Windows-*", "configurations:Release"})
   if qt_dir then
     links({
       "Qt6Core",
@@ -371,7 +622,7 @@ filter({"platforms:Windows", "configurations:Release"})
     })
   end
 
-filter({"platforms:Windows", "configurations:Debug or Checked"})
+filter({"platforms:Windows-*", "configurations:Debug or Checked"})
   if qt_dir then
     links({
       "Qt6Cored",
@@ -380,10 +631,10 @@ filter({"platforms:Windows", "configurations:Debug or Checked"})
     })
   end
 
-filter("platforms:Windows")
+filter("platforms:Windows-*")
 
 -- Embed the manifest for things like dependencies and DPI awareness.
-filter({"platforms:Windows", "kind:ConsoleApp or WindowedApp"})
+filter({"platforms:Windows-*", "kind:ConsoleApp or WindowedApp"})
   files({
     "src/xenia/base/app_win32.manifest"
   })
@@ -404,16 +655,46 @@ workspace("xenia")
       architecture("x86_64")
     filter({})
   else
-    architecture("x86_64")
     if os.istarget("linux") then
-      platforms({"Linux"})
+      if TARGET_ARCH == "ARM64" then
+        platforms({"Linux-ARM64"})
+        architecture("ARM64")
+      else
+        platforms({"Linux-x86_64"})
+        architecture("x86_64")
+      end
     elseif os.istarget("macosx") then
-      platforms({"Mac"})
-      xcodebuildsettings({
-        ["ARCHS"] = "x86_64"
-      })
+      local mac_platforms = nil
+      if is_macos_arm64_host() then
+        if _OPTIONS["mac-x86_64"] then
+          mac_platforms = {"Mac-x86_64"}
+        else
+          mac_platforms = {"Mac-ARM64"}
+        end
+      else
+        mac_platforms = {"Mac-x86_64"}
+      end
+      platforms(mac_platforms)
+      filter("platforms:Mac-ARM64")
+        architecture("ARM64")
+        xcodebuildsettings({
+          ["ARCHS"] = "arm64",
+        })
+      filter("platforms:Mac-x86_64")
+        architecture("x86_64")
+        xcodebuildsettings({
+          ["ARCHS"] = "x86_64",
+          ["CLANG_X86_VECTOR_INSTRUCTION_SET"] = "avx",
+        })
+      filter({})
     elseif os.istarget("windows") then
-      platforms({"Windows"})
+      if TARGET_ARCH == "ARM64" then
+        platforms({"Windows-ARM64"})
+        architecture("ARM64")
+      else
+        platforms({"Windows-x86_64"})
+        architecture("x86_64")
+      end
       -- 10.0.15063.0: ID3D12GraphicsCommandList1::SetSamplePositions.
       -- 10.0.19041.0: D3D12_HEAP_FLAG_CREATE_NOT_ZEROED.
       -- 10.0.22000.0: DWMWA_WINDOW_CORNER_PREFERENCE.
@@ -434,8 +715,6 @@ workspace("xenia")
   include("third_party/fmt.lua")
   include("third_party/glslang-spirv.lua")
   include("third_party/imgui.lua")
-  include("third_party/metal-shader-converter.lua")
-  include("third_party/metal-cpp.lua")
   include("third_party/miniaudio.lua")
   include("third_party/mspack.lua")
   include("third_party/snappy.lua")
@@ -468,7 +747,7 @@ workspace("xenia")
     })
     removefatalwarnings("All")
 
-    filter({"platforms:Linux", "configurations:Checked"})
+    filter({"platforms:Linux-*", "configurations:Checked"})
       buildoptions({
         "-fsanitize=undefined",
       })
@@ -479,7 +758,23 @@ workspace("xenia")
 
     -- Add POSIX feature test macros for FFmpeg on Linux
     if prj.name == "libavutil" or prj.name == "libavcodec" or prj.name == "libavformat" then
-      filter({"platforms:Linux"})
+      -- Keep FFmpeg premake files from commit 85e39939 compatible with split
+      -- platform names until FFmpeg submodule updates are pulled in.
+      filter({"platforms:Windows-*"})
+        includedirs({
+          "third_party/FFmpeg/compat/atomics/win32",
+        })
+        forceincludes({
+          "stdatomic.h",
+        })
+        links({
+          "bcrypt",
+        })
+      filter({"platforms:Linux-* or platforms:Mac-*"})
+        includedirs({
+          "third_party/FFmpeg/compat/atomics/gcc",
+        })
+      filter({"platforms:Linux-*"})
         defines({
           "_GNU_SOURCE",
           "_POSIX_C_SOURCE=200809L",
@@ -498,8 +793,46 @@ workspace("xenia")
       filter({})
     end
 
+    if prj.name == "libavcodec" then
+      filter({"platforms:Linux-x86_64 or platforms:Windows-x86_64"})
+        files({
+          "third_party/FFmpeg/libavcodec/x86/constants.c",
+          "third_party/FFmpeg/libavcodec/x86/dct_init.c",
+          "third_party/FFmpeg/libavcodec/x86/fdctdsp_init.c",
+          "third_party/FFmpeg/libavcodec/x86/fft_init.c",
+          "third_party/FFmpeg/libavcodec/x86/idctdsp_init.c",
+          "third_party/FFmpeg/libavcodec/x86/mpegaudiodsp.c",
+          "third_party/FFmpeg/libavcodec/x86/fdct.c",
+        })
+      filter({"platforms:Windows-*"})
+        files({
+          "third_party/FFmpeg/libavcodec/file_open.c",
+        })
+      filter({})
+    end
+
+    if prj.name == "libavutil" then
+      filter({"platforms:Linux-x86_64 or platforms:Windows-x86_64"})
+        files({
+          "third_party/FFmpeg/libavutil/x86/cpu.c",
+          "third_party/FFmpeg/libavutil/x86/fixed_dsp_init.c",
+          "third_party/FFmpeg/libavutil/x86/float_dsp_init.c",
+          "third_party/FFmpeg/libavutil/x86/imgutils_init.c",
+          "third_party/FFmpeg/libavutil/x86/lls_init.c",
+        })
+      filter({})
+    end
+
+    if prj.name == "libavformat" then
+      filter({"platforms:Windows-*"})
+        files({
+          "third_party/FFmpeg/libavformat/file_open.c",
+        })
+      filter({})
+    end
+
     -- Suppress warnings for third_party modules on Windows
-    filter({"platforms:Windows"})
+    filter({"platforms:Windows-*"})
       if string.startswith(prj.name, "third_party") or
          prj.name == "aes_128" or
          prj.name == "capstone" or
@@ -534,9 +867,17 @@ workspace("xenia")
   include("src/xenia/apu/nop")
   include("src/xenia/base")
   include("src/xenia/cpu")
-  include("src/xenia/cpu/backend/x64")
+  if TARGET_ARCH == "ARM64" then
+    include("src/xenia/cpu/backend/a64")
+  end
+  if TARGET_ARCH == "x86_64" then
+    include("src/xenia/cpu/backend/x64")
+  end
   include("src/xenia/debug/ui")
   include("src/xenia/gpu")
+  if os.istarget("macosx") then
+    include("src/xenia/gpu/metal")
+  end
   include("src/xenia/gpu/null")
   include("src/xenia/gpu/vulkan")
   include("src/xenia/hid")
@@ -545,6 +886,9 @@ workspace("xenia")
   include("src/xenia/kernel")
   include("src/xenia/patcher")
   include("src/xenia/ui")
+  if os.istarget("macosx") then
+    include("src/xenia/ui/metal")
+  end
   include("src/xenia/ui/vulkan")
   include("src/xenia/vfs")
 

--- a/src/xenia/app/premake5.lua
+++ b/src/xenia/app/premake5.lua
@@ -1,4 +1,12 @@
 project_root = "../../.."
+local metal_converter_libdir =
+    path.getabsolute(path.join(project_root, "third_party/metal-shader-converter/lib"))
+local dxilconv_libdir_arm64 =
+    path.getabsolute(path.join(project_root,
+                               "third_party/DirectXShaderCompiler/build_dxilconv_macos/lib"))
+local dxilconv_libdir_x86_64 =
+    path.getabsolute(path.join(project_root,
+                               "third_party/DirectXShaderCompiler/build_dxilconv_macos_x86_64/lib"))
 include(project_root.."/tools/build")
 
 group("src")
@@ -13,13 +21,11 @@ project("xenia-app")
     "xenia-cpu",
     "xenia-gpu",
     "xenia-gpu-null",
-    "xenia-gpu-vulkan",
     "xenia-hid",
     "xenia-hid-nop",
     "xenia-kernel",
     "xenia-patcher",
     "xenia-ui",
-    "xenia-ui-vulkan",
     "xenia-vfs",
   })
   links({
@@ -64,7 +70,7 @@ project("xenia-app")
   end
   filter(NOT_SINGLE_LIBRARY_FILTER)
     kind("WindowedApp")
-  filter({NOT_SINGLE_LIBRARY_FILTER, "platforms:Windows", "configurations:Debug"})
+  filter({NOT_SINGLE_LIBRARY_FILTER, "platforms:Windows-*", "configurations:Debug"})
     kind("ConsoleApp")
 
   -- `targetname` is broken if building from Gradle, works only for toggling the
@@ -84,11 +90,17 @@ project("xenia-app")
       "xenia_main.cc",
     })
 
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     files({
       "main_resources.rc",
     })
     linkoptions({"/ENTRY:mainCRTStartup"})
+
+  filter("not system:macosx")
+    links({
+      "xenia-gpu-vulkan",
+      "xenia-ui-vulkan",
+    })
 
   filter({"architecture:x86_64", "files:../base/main_init_"..platform_suffix..".cc"})
     vectorextensions("SSE2")  -- Disable AVX for main_init_win.cc so our AVX check doesn't use AVX instructions.
@@ -103,7 +115,12 @@ project("xenia-app")
       "xenia-hid-sdl",
     })
 
-  filter("platforms:Linux")
+  filter({"platforms:not Android-*", "architecture:ARM64"})
+    links({
+      "xenia-cpu-backend-a64",
+    })
+
+  filter("platforms:Linux-*")
     links({
       "xenia-apu-alsa",
       "X11",
@@ -112,7 +129,7 @@ project("xenia-app")
       "SDL2",
     })
 
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     links({
       "xenia-apu-xaudio2",
       "xenia-debug-gdb",
@@ -121,18 +138,56 @@ project("xenia-app")
       "xenia-hid-xinput",
       "xenia-ui-d3d12",
     })
+    includedirs({
+      project_root.."/third_party/DirectXShaderCompiler/include",
+    })
 
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
+
+  filter("system:macosx")
+    xcodebuildsettings({
+      ["LD_RUNPATH_SEARCH_PATHS"] =
+          "@executable_path/../Frameworks @loader_path/../Frameworks",
+    })
+    links({
+      "xenia-gpu-metal",
+      "xenia-ui-metal",
+      "dxilconv",
+      "metalirconverter",
+      "Cocoa.framework",
+      "CoreFoundation.framework",
+      "CoreServices.framework",
+      "Foundation.framework",
+      "Metal.framework",
+      "MetalFX.framework",
+      "MetalKit.framework",
+      "QuartzCore.framework",
+      "SDL2",
+    })
+    linkoptions({
+      "-ldxilconv",
+      "-lLLVMDxcSupport",
+    })
+    libdirs({
+      metal_converter_libdir,
+      "/opt/homebrew/opt/sdl2/lib",
+      "/usr/local/opt/sdl2/lib",
+    })
+  filter({"system:macosx", "architecture:arm64"})
+    libdirs({ dxilconv_libdir_arm64 })
+  filter({"system:macosx", "architecture:x86_64"})
+    libdirs({ dxilconv_libdir_x86_64 })
+  filter({})
 
   if enableMiscSubprojects then
-    filter({"platforms:Windows", SINGLE_LIBRARY_FILTER})
+    filter({"platforms:Windows-*", SINGLE_LIBRARY_FILTER})
       links({
         "xenia-gpu-d3d12-trace-viewer",
         "xenia-ui-window-d3d12-demo",
       })
   end
 
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     -- Only create the .user file if it doesn't already exist.
     local user_file = project_root.."/build/xenia-app.vcxproj.user"
     if not os.isfile(user_file) then
@@ -140,7 +195,7 @@ project("xenia-app")
     end
 
   -- Run windeployqt as post-build event to copy Qt DLLs
-  filter({"platforms:Windows", "configurations:Debug or Checked"})
+  filter({"platforms:Windows-*", "configurations:Debug or Checked"})
     local qt_dir = os.getenv("QT_DIR")
     if qt_dir then
       local windeployqt = path.translate(path.join(qt_dir, "bin", "windeployqt.exe"), "\\")
@@ -149,7 +204,7 @@ project("xenia-app")
       }
     end
 
-  filter({"platforms:Windows", "configurations:Release"})
+  filter({"platforms:Windows-*", "configurations:Release"})
     local qt_dir = os.getenv("QT_DIR")
     if qt_dir then
       local windeployqt = path.translate(path.join(qt_dir, "bin", "windeployqt.exe"), "\\")
@@ -159,7 +214,7 @@ project("xenia-app")
     end
 
   -- Copy optimized-settings JSON files next to executable
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     -- Use absolute path to avoid issues with relative paths
     local optimized_settings_src = path.translate(path.getabsolute(path.join(project_root, ".data_repos", "optimized-settings", "settings")), "\\")
     postbuildcommands {
@@ -168,7 +223,7 @@ project("xenia-app")
     }
 
   -- Copy game-patches TOML files next to executable
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     local game_patches_src = path.translate(path.getabsolute(path.join(project_root, ".data_repos", "game-patches", "patches")), "\\")
     postbuildcommands {
       'if not exist "$(TargetDir)game_patches" mkdir "$(TargetDir)game_patches"',
@@ -176,14 +231,14 @@ project("xenia-app")
     }
 
   -- Copy assets/font next to executable
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     local assets_font_src = path.translate(path.getabsolute(path.join(project_root, "assets", "font")), "\\")
     postbuildcommands {
       'if not exist "$(TargetDir)assets\\font" mkdir "$(TargetDir)assets\\font"',
       'xcopy /I /Y /Q "' .. assets_font_src .. '\\*.*" "$(TargetDir)assets\\font\\"'
     }
 
-  filter("platforms:Linux")
+  filter("platforms:Linux-*")
     local optimized_settings_src = path.getabsolute(path.join(project_root, ".data_repos", "optimized-settings", "settings"))
     local optimized_settings_dst = path.getabsolute(path.join(project_root, "build", "bin", "Linux")) .. "/%{cfg.buildcfg}/optimized_settings"
     postbuildcommands {
@@ -191,7 +246,7 @@ project("xenia-app")
       '{COPY} ' .. optimized_settings_src .. '/*.json ' .. optimized_settings_dst
     }
 
-  filter("platforms:Linux")
+  filter("platforms:Linux-*")
     local game_patches_src = path.getabsolute(path.join(project_root, ".data_repos", "game-patches", "patches"))
     local game_patches_dst = path.getabsolute(path.join(project_root, "build", "bin", "Linux")) .. "/%{cfg.buildcfg}/game_patches"
     postbuildcommands {
@@ -200,7 +255,7 @@ project("xenia-app")
     }
 
   -- Copy assets/font next to executable
-  filter("platforms:Linux")
+  filter("platforms:Linux-*")
     local assets_font_src = path.getabsolute(path.join(project_root, "assets", "font"))
     local assets_font_dst = path.getabsolute(path.join(project_root, "build", "bin", "Linux")) .. "/%{cfg.buildcfg}/assets/font"
     postbuildcommands {

--- a/src/xenia/apu/alsa/premake5.lua
+++ b/src/xenia/apu/alsa/premake5.lua
@@ -11,7 +11,7 @@ project("xenia-apu-alsa")
   })
   local_platform_files()
 
-  filter("platforms:Linux")
+  filter("platforms:Linux-*")
     links({
       "asound",
       "pthread",

--- a/src/xenia/apu/premake5.lua
+++ b/src/xenia/apu/premake5.lua
@@ -15,7 +15,7 @@ project("xenia-apu")
   includedirs({
     project_root.."/third_party/FFmpeg",
   })
-  filter("platforms:Linux")
+  filter("platforms:Linux-*")
     links({
       "xenia-helper-sdl",
       "SDL2",

--- a/src/xenia/cpu/ppc/testing/premake5.lua
+++ b/src/xenia/cpu/ppc/testing/premake5.lua
@@ -29,7 +29,7 @@ project("xenia-cpu-ppc-tests")
   })
   apu_transitive_deps()
   -- Qt is required because xenia-kernel now uses Qt for achievements dialog
-  filter("platforms:Linux")
+  filter("platforms:Linux-*")
     local qt_dir = os.getenv("QT_DIR")
     if qt_dir then
       links({
@@ -54,7 +54,7 @@ project("xenia-cpu-ppc-tests")
     links({
       "xenia-cpu-backend-x64",
     })
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     debugdir(project_root)
     debugargs({
       "2>&1",

--- a/src/xenia/debug/gdb/premake5.lua
+++ b/src/xenia/debug/gdb/premake5.lua
@@ -12,7 +12,7 @@ project("xenia-debug-gdb")
     "xenia-cpu",
     "xenia-ui",
   })
-  filter({"configurations:Release", "platforms:Windows"})
+  filter({"configurations:Release", "platforms:Windows-*"})
     buildoptions({
       "/Os",
       "/O1"

--- a/src/xenia/gpu/premake5.lua
+++ b/src/xenia/gpu/premake5.lua
@@ -21,7 +21,7 @@ project("xenia-gpu")
   })
 
   -- Include SPIRV-Tools headers from Vulkan SDK for Windows
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     includedirs({
       "$(VULKAN_SDK)/Include",
     })
@@ -54,13 +54,13 @@ if enableMiscSubprojects then
     })
 
     -- Include SPIRV-Tools headers from Vulkan SDK
-    filter("platforms:Windows")
+    filter("platforms:Windows-*")
       includedirs({
         "$(VULKAN_SDK)/Include",
       })
     filter({})
 
-    filter("platforms:Windows")
+    filter("platforms:Windows-*")
       -- Only create the .user file if it doesn't already exist.
       local user_file = project_root.."/build/xenia-gpu-shader-compiler.vcxproj.user"
       if not os.isfile(user_file) then

--- a/src/xenia/gpu/vulkan/premake5.lua
+++ b/src/xenia/gpu/vulkan/premake5.lua
@@ -21,7 +21,7 @@ project("xenia-gpu-vulkan")
   })
 
   -- Include SPIRV-Tools headers from Vulkan SDK for Windows
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     includedirs({
       "$(VULKAN_SDK)/Include",
     })
@@ -82,14 +82,14 @@ if enableMiscSubprojects then
         "xenia-cpu-backend-x64",
       })
 
-    filter("platforms:Linux")
+    filter("platforms:Linux-*")
       links({
         "X11",
         "xcb",
         "X11-xcb",
       })
 
-    filter("platforms:Windows")
+    filter("platforms:Windows-*")
       -- Only create the .user file if it doesn't already exist.
       local user_file = project_root.."/build/xenia-gpu-vulkan-trace-viewer.vcxproj.user"
       if not os.isfile(user_file) then
@@ -149,14 +149,14 @@ if enableMiscSubprojects then
         "xenia-cpu-backend-x64",
       })
 
-    filter("platforms:Linux")
+    filter("platforms:Linux-*")
       links({
         "X11",
         "xcb",
         "X11-xcb",
       })
 
-    filter("platforms:Windows")
+    filter("platforms:Windows-*")
       -- Only create the .user file if it doesn't already exist.
       local user_file = project_root.."/build/xenia-gpu-vulkan-trace-dump.vcxproj.user"
       if not os.isfile(user_file) then

--- a/src/xenia/hid/skylander/premake5.lua
+++ b/src/xenia/hid/skylander/premake5.lua
@@ -13,7 +13,7 @@ project("xenia-hid-skylander")
       "skylander_emulated.cc"
   })
 
-  filter({"platforms:Windows"})
+  filter({"platforms:Windows-*"})
     links({
       "libusb",
     })

--- a/src/xenia/kernel/premake5.lua
+++ b/src/xenia/kernel/premake5.lua
@@ -6,14 +6,14 @@ project("xenia-kernel")
   uuid("ae185c4a-1c4f-4503-9892-328e549e871a")
   kind("StaticLib")
   language("C++")
-  includedirs({
+  sysincludedirs({
     project_root.."/third_party/asio/include",
   })
   defines({
     "ASIO_STANDALONE",
     "ASIO_NO_DEPRECATED",
   })
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     defines({
       "_WIN32_WINNT=0x0A00",  -- Windows 10+ for Asio
       "_WINSOCK_DEPRECATED_NO_WARNINGS",  -- Suppress deprecated Winsock API warnings

--- a/src/xenia/ui/premake5.lua
+++ b/src/xenia/ui/premake5.lua
@@ -19,14 +19,14 @@ project("xenia-ui")
       wholelib("On")
   end
 
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     links({
       "dwmapi",
       "dxgi",
       "winmm",
     })
 
-  filter("platforms:Linux")
+  filter("platforms:Linux-*")
     links({
       "xcb",
       "X11",

--- a/src/xenia/ui/vulkan/premake5.lua
+++ b/src/xenia/ui/vulkan/premake5.lua
@@ -16,7 +16,7 @@ project("xenia-ui-vulkan")
   })
 
   -- Include SPIRV-Tools from Vulkan SDK
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     includedirs({
       "$(VULKAN_SDK)/Include",
     })
@@ -28,7 +28,7 @@ project("xenia-ui-vulkan")
       "SPIRV-Tools.lib",
     })
 
-  filter("platforms:Linux")
+  filter("platforms:Linux-*")
     links({
       "SPIRV-Tools-opt",
       "SPIRV-Tools",
@@ -88,7 +88,7 @@ if enableMiscSubprojects then
         "xenia-cpu-backend-x64",
       })
 
-    filter("platforms:Linux")
+    filter("platforms:Linux-*")
       links({
         "X11",
         "xcb",

--- a/third_party/SDL2.lua
+++ b/third_party/SDL2.lua
@@ -69,11 +69,11 @@ end
 -- Call this function in project scope to include the SDL2 headers.
 --
 function sdl2_include()
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     includedirs({
       path.getrelative(".", third_party_path) .. "/SDL2/include",
     })
-  filter("platforms:Linux or Mac")
+  filter("platforms:Linux-* or platforms:Mac-*")
     includedirs(sdl2_sys_includedirs)
     libdirs(sdl2_sys_libdirs)
   filter({})

--- a/third_party/asio.lua
+++ b/third_party/asio.lua
@@ -13,7 +13,7 @@ project("asio")
     "ASIO_NO_DEPRECATED",
   })
 
-  filter("platforms:Windows")
+  filter("platforms:Windows-*")
     defines({
       "_WIN32_WINNT=0x0A00",  -- Windows 10+
     })

--- a/third_party/libusb.lua
+++ b/third_party/libusb.lua
@@ -16,7 +16,7 @@ project("libusb")
     "libusb/libusb/sync.c",
   })
 
-  filter({"platforms:Windows"})
+  filter({"platforms:Windows-*"})
     includedirs({
       "libusb/msvc",
     })
@@ -33,7 +33,7 @@ project("libusb")
       "libusb/libusb/os/windows_winusb.h"
     })
 
-  filter({"platforms:Linux"})
+  filter({"platforms:Linux-*"})
     files({
       "libusb/libusb/config.h",
       "libusb/libusb/os/events_posix.c",

--- a/tools/build/premake.py
+++ b/tools/build/premake.py
@@ -10,6 +10,7 @@ __author__ = "ben.vanik@gmail.com (Ben Vanik)"
 
 from json import loads as jsonloads
 import os
+import platform
 from shutil import rmtree
 import subprocess
 import sys
@@ -52,15 +53,15 @@ setup_premake_path_override()
 def main():
     # First try the freshly-built premake.
     premake5_bin = os.path.join(premake_path, "bin", "release", "premake5")
-    if not has_bin(premake5_bin):
+    if not is_premake_usable(premake5_bin):
         # No fresh build, so fallback to checked in copy (which we may not have).
         premake5_bin = os.path.join(self_path, "bin", "premake5")
-    if not has_bin(premake5_bin):
+    if not is_premake_usable(premake5_bin):
         # Still no valid binary, so build it.
-        print("premake5 executable not found, attempting build...")
+        print("premake5 executable not found or unusable, attempting build...")
         build_premake()
         premake5_bin = os.path.join(premake_path, "bin", "release", "premake5")
-    if not has_bin(premake5_bin):
+    if not is_premake_usable(premake5_bin):
         # Nope, boned.
         print("ERROR: cannot build premake5 executable.")
         sys.exit(1)
@@ -92,11 +93,18 @@ def build_premake():
     try:
         os.chdir(premake_path)
         if sys.platform == "darwin":
-            subprocess.call([
-                "make",
-                "-f", "Bootstrap.mak",
-                "osx",
-                ])
+            premake_arch = platform.machine()
+            if premake_arch in ["arm64", "aarch64"]:
+                premake_arch = "ARM64"
+            elif premake_arch in ["x86_64", "amd64"]:
+                premake_arch = "x86_64"
+            else:
+                premake_arch = None
+            make_args = ["make", "-f", "Bootstrap.mak"]
+            if premake_arch:
+                make_args.append(f"PLATFORM={premake_arch}")
+            make_args.append("osx")
+            subprocess.call(make_args)
         elif sys.platform == "win32":
             # Grab Visual Studio version and execute shell to set up environment.
             vs_version = import_vs_environment()
@@ -119,6 +127,26 @@ def build_premake():
     finally:
         os.chdir(cwd)
     pass
+
+
+def is_premake_usable(premake5_bin):
+    if not has_bin(premake5_bin):
+        return False
+    if sys.platform == "darwin":
+        try:
+            subprocess.check_call(
+                [premake5_bin, "--version"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except OSError as e:
+            # Errno 86: Bad CPU type in executable (wrong arch).
+            if e.errno == 86:
+                print("premake5 executable has wrong architecture, rebuilding...")
+            return False
+        except subprocess.CalledProcessError:
+            return False
+    return True
 
 
 def clone_premake_to_internal_storage():

--- a/tools/build/scripts/apu_deps.lua
+++ b/tools/build/scripts/apu_deps.lua
@@ -3,7 +3,7 @@
 -- On Linux, xenia-apu's AudioMediaPlayer directly instantiates SDLAudioDriver,
 -- so consumers must link xenia-apu-sdl (which in turn brings in xenia-helper-sdl and SDL2)
 function apu_transitive_deps()
-  filter("platforms:Linux")
+  filter("platforms:Linux-*")
     links({
       "xenia-apu-sdl",  -- Contains SDLAudioDriver used by AudioMediaPlayer
     })

--- a/tools/build/scripts/build_paths.lua
+++ b/tools/build/scripts/build_paths.lua
@@ -11,6 +11,8 @@ if os.istarget("android") then
   platform_suffix = "android"
 elseif os.istarget("windows") then
   platform_suffix = "win"
+elseif os.istarget("macosx") then
+  platform_suffix = "mac"
 else
   platform_suffix = "posix"
 end

--- a/tools/build/scripts/platform_files.lua
+++ b/tools/build/scripts/platform_files.lua
@@ -9,39 +9,30 @@ local function match_platform_files(base_path, base_match)
     base_path.."/"..base_match..".cpp",
     base_path.."/"..base_match..".inc",
   })
-  removefiles({
-    base_path.."/".."**_main.cc",
-    base_path.."/".."**_test.cc",
-    base_path.."/".."**_posix.h",
-    base_path.."/".."**_posix.cc",
-    base_path.."/".."**_linux.h",
-    base_path.."/".."**_linux.cc",
-    base_path.."/".."**_gnulinux.h",
-    base_path.."/".."**_gnulinux.cc",
-    base_path.."/".."**_x11.h",
-    base_path.."/".."**_x11.cc",
-    base_path.."/".."**_gtk.h",
-    base_path.."/".."**_gtk.cc",
-    base_path.."/".."**_android.h",
-    base_path.."/".."**_android.cc",
-    base_path.."/".."**_mac.h",
-    base_path.."/".."**_mac.cc",
-    base_path.."/".."**_win.h",
-    base_path.."/".."**_win.cc",
-  })
-  filter("platforms:Windows")
+  removefiles({base_path.."/".."**_main.cc"})
+  removefiles({base_path.."/".."**_test.cc"})
+  removefiles({base_path.."/".."**_posix.h", base_path.."/".."**_posix.cc"})
+  removefiles({base_path.."/".."**_linux.h", base_path.."/".."**_linux.cc"})
+  removefiles({base_path.."/".."**_gnulinux.h",
+               base_path.."/".."**_gnulinux.cc"})
+  removefiles({base_path.."/".."**_x11.h", base_path.."/".."**_x11.cc"})
+  removefiles({base_path.."/".."**_gtk.h", base_path.."/".."**_gtk.cc"})
+  removefiles({base_path.."/".."**_android.h", base_path.."/".."**_android.cc"})
+  removefiles({base_path.."/".."**_mac.h", base_path.."/".."**_mac.cc"})
+  removefiles({base_path.."/".."**_win.h", base_path.."/".."**_win.cc"})
+  filter("platforms:Windows-*")
     files({
       base_path.."/"..base_match.."_win.h",
       base_path.."/"..base_match.."_win.cc",
     })
-  filter("platforms:Linux or Android-*")
+  filter("platforms:Linux-* or Android-*")
     files({
       base_path.."/"..base_match.."_posix.h",
       base_path.."/"..base_match.."_posix.cc",
       base_path.."/"..base_match.."_linux.h",
       base_path.."/"..base_match.."_linux.cc",
     })
-  filter("platforms:Linux")
+  filter("platforms:Linux-*")
     files({
       base_path.."/"..base_match.."_gnulinux.h",
       base_path.."/"..base_match.."_gnulinux.cc",
@@ -50,6 +41,23 @@ local function match_platform_files(base_path, base_match)
       base_path.."/"..base_match.."_gtk.h",
       base_path.."/"..base_match.."_gtk.cc",
     })
+  filter("platforms:Mac-*")
+    -- First add all Mac-specific files.
+    files({
+      base_path.."/"..base_match.."_mac.h",
+      base_path.."/"..base_match.."_mac.cc",
+    })
+    -- Then add POSIX files as fallbacks.
+    files({
+      base_path.."/"..base_match.."_posix.h",
+      base_path.."/"..base_match.."_posix.cc",
+    })
+    -- Remove POSIX fallback when a Mac-specific file exists.
+    local mac_files = os.matchfiles(base_path.."/"..base_match.."_mac.cc")
+    for _, mac_file in ipairs(mac_files) do
+      local posix_file = mac_file:gsub("_mac%.cc$", "_posix.cc")
+      removefiles({posix_file})
+    end
   filter("platforms:Android-*")
     files({
       base_path.."/"..base_match.."_android.h",

--- a/tools/build/scripts/test_suite.lua
+++ b/tools/build/scripts/test_suite.lua
@@ -12,6 +12,14 @@ newoption({
 })
 
 local function combined_test_suite(test_suite_name, project_root, base_path, config)
+  local console_app_main_suffix = platform_suffix
+  if platform_suffix == "mac" then
+    local mac_console_main =
+        project_root.."/src/xenia/base/console_app_main_mac.cc"
+    if not os.isfile(mac_console_main) then
+      console_app_main_suffix = "posix"
+    end
+  end
   group("tests")
   project(test_suite_name)
     kind("ConsoleApp")
@@ -37,7 +45,7 @@ local function combined_test_suite(test_suite_name, project_root, base_path, con
     })
     files({
       project_root.."/"..build_tools_src.."/test_suite_main.cc",
-      project_root.."/src/xenia/base/console_app_main_"..platform_suffix..".cc",
+      project_root.."/src/xenia/base/console_app_main_"..console_app_main_suffix..".cc",
       base_path.."/**_test.cc",
     })
     filter("toolset:msc")

--- a/xenia-build.py
+++ b/xenia-build.py
@@ -898,7 +898,28 @@ def get_premake_target_os(target_os_override=None):
     return target_os
 
 
-def run_premake(target_os, action, cc=None):
+def normalize_arch_name(arch):
+    if not arch:
+        return None
+    arch = arch.lower()
+    if arch in ("arm64", "aarch64"):
+        return "arm64"
+    if arch in ("x86_64", "x64", "amd64"):
+        return "x86_64"
+    return None
+
+
+def detect_host_arch():
+    if sys.platform == "win32":
+        machine = (os.environ.get("PROCESSOR_ARCHITEW6432")
+                   or os.environ.get("PROCESSOR_ARCHITECTURE")
+                   or "").upper()
+        return "arm64" if "ARM64" in machine else "x86_64"
+    machine = os.uname().machine.lower()
+    return "arm64" if machine in ("arm64", "aarch64") else "x86_64"
+
+
+def run_premake(target_os, action, cc=None, arch=None):
     """Runs premake on the main project with the given format.
 
     Args:
@@ -919,6 +940,8 @@ def run_premake(target_os, action, cc=None):
 
     if cc:
         args.insert(4, f"--cc={cc}")
+    if arch:
+        args.insert(5, f"--arch={arch}")
 
     ret = subprocess.call(args)
 
@@ -928,7 +951,7 @@ def run_premake(target_os, action, cc=None):
     return ret
 
 
-def run_platform_premake(target_os_override=None, cc=None, devenv=None):
+def run_platform_premake(target_os_override=None, cc=None, devenv=None, arch=None):
     """Runs all gyp configurations.
     """
     target_os = get_premake_target_os(target_os_override)
@@ -946,7 +969,7 @@ def run_platform_premake(target_os_override=None, cc=None, devenv=None):
             devenv = "cmake"
     if not cc:
         cc = get_cc(cc=cc)
-    return run_premake(target_os=target_os, action=devenv, cc=cc)
+    return run_premake(target_os=target_os, action=devenv, cc=cc, arch=arch)
 
 
 def get_build_bin_path(args):
@@ -959,13 +982,14 @@ def get_build_bin_path(args):
     Returns:
       A full path for the bin folder.
     """
+    arch = normalize_arch_name(args.get("arch")) or detect_host_arch()
     if sys.platform == "darwin":
-        platform = "macosx"
+        platform = "Mac-ARM64" if arch == "arm64" else "Mac-x86_64"
     elif sys.platform == "win32":
-        platform = "windows"
+        platform = "Windows-ARM64" if arch == "arm64" else "Windows-x86_64"
     else:
-        platform = "linux"
-    return os.path.join(self_path, "build", "bin", platform.capitalize(), args["config"].capitalize())
+        platform = "Linux-ARM64" if arch == "arm64" else "Linux-x86_64"
+    return os.path.join(self_path, "build", "bin", platform, args["config"].capitalize())
 
 
 def run_windeployqt(bin_path, config):
@@ -1255,6 +1279,9 @@ class PremakeCommand(Command):
         self.parser.add_argument(
             "--devenv", default=None, help="Development environment")
         self.parser.add_argument(
+            "--arch", choices=["x86_64", "arm64"], default=None,
+            type=str.lower, help="Target architecture passed to premake.")
+        self.parser.add_argument(
             "--target_os", default=None,
             help="Target OS passed to premake, for cross-compilation")
 
@@ -1262,7 +1289,8 @@ class PremakeCommand(Command):
         # Update premake. If no binary found, it will be built from source.
         print("Running premake...\n")
         ret = run_platform_premake(target_os_override=args["target_os"],
-                                   cc=args["cc"], devenv=args["devenv"])
+                                   cc=args["cc"], devenv=args["devenv"],
+                                   arch=args["arch"])
         print_status(ResultStatus.SUCCESS if not ret else ResultStatus.FAILURE)
 
         return ret
@@ -1285,6 +1313,10 @@ class BaseBuildCommand(Command):
             "--target", action="append", default=[],
             help="Builds only the given target(s).")
         self.parser.add_argument(
+            "--arch", choices=["x86_64", "arm64"], default=None,
+            type=str.lower,
+            help="Target architecture passed to premake (defaults to host arch).")
+        self.parser.add_argument(
             "--force", action="store_true",
             help="Forces a full rebuild.")
         self.parser.add_argument(
@@ -1302,7 +1334,7 @@ class BaseBuildCommand(Command):
 
         if not args["no_premake"]:
             print("- running premake...")
-            run_platform_premake(cc=args["cc"])
+            run_platform_premake(cc=args["cc"], arch=args["arch"])
             print("")
 
         print("- building (%s):%s..." % (
@@ -1313,14 +1345,22 @@ class BaseBuildCommand(Command):
                 print_error("Visual Studio is not installed.")
                 result = 1
             else:
+                arch = normalize_arch_name(args.get("arch")) or detect_host_arch()
+                if arch == "arm64":
+                    premake_platform = "Windows-ARM64"
+                    msbuild_platform = "ARM64"
+                else:
+                    premake_platform = "Windows-x86_64"
+                    msbuild_platform = "x64"
+
                 targets = None
                 if args["target"]:
                     # Build each project file directly to avoid MSBuild trying to
                     # run the target on every project in the solution
                     result = 0
                     # Convert config name to match project configuration names
-                    # e.g., "debug" -> "Debug Windows"
-                    config_name = f"{args['config'].capitalize()} Windows"
+                    # e.g., "debug" -> "Debug Windows-x86_64"
+                    config_name = f"{args['config'].capitalize()} {premake_platform}"
                     for target in args["target"]:
                         project_file = f"build/{target}.vcxproj"
                         if not os.path.exists(project_file):
@@ -1337,7 +1377,7 @@ class BaseBuildCommand(Command):
                             "/v:m",
                             target_arg,
                             f"/p:Configuration={config_name}",
-                            "/p:Platform=x64",
+                            f"/p:Platform={msbuild_platform}",
                             ] + pass_args)
                         if result != 0:
                             break
@@ -1439,7 +1479,7 @@ class BuildShadersCommand(Command):
             """,
             *args, **kwargs)
         self.parser.add_argument(
-            "--target", action="append", choices=["dxbc", "spirv"], default=[],
+            "--target", action="append", choices=["dxbc", "spirv", "metal"], default=[],
             help="Builds only the given target(s).")
 
     def execute(self, args, pass_args, cwd):
@@ -1450,7 +1490,7 @@ def build_shaders(targets=None):
     """Builds shader bytecode. Called by BuildShadersCommand and BuildCommand.
 
     Args:
-        targets: List of targets ("dxbc", "spirv"), or None/empty for all.
+        targets: List of targets ("dxbc", "spirv", "metal"), or None/empty for all.
 
     Returns:
         0 on success, non-zero on error.
@@ -1458,15 +1498,22 @@ def build_shaders(targets=None):
     # Check if shaders need rebuilding by comparing source vs generated timestamps
     gpu_shaders = "src/xenia/gpu/shaders"
     ui_shaders = "src/xenia/ui/shaders"
-    # DXBC directories only on Windows, SPIR-V everywhere
-    bytecode_dirs = [
-        "src/xenia/gpu/shaders/bytecode/vulkan_spirv",
-        "src/xenia/ui/shaders/bytecode/vulkan_spirv",
-    ]
+    # DXBC directories only on Windows, SPIR-V on non-mac platforms.
+    bytecode_dirs = []
+    if sys.platform != "darwin":
+        bytecode_dirs.extend([
+            "src/xenia/gpu/shaders/bytecode/vulkan_spirv",
+            "src/xenia/ui/shaders/bytecode/vulkan_spirv",
+        ])
     if sys.platform == "win32":
         bytecode_dirs.extend([
             "src/xenia/gpu/shaders/bytecode/d3d12_5_1",
             "src/xenia/ui/shaders/bytecode/d3d12_5_1",
+        ])
+    if sys.platform == "darwin":
+        bytecode_dirs.extend([
+            "src/xenia/gpu/shaders/bytecode/metal",
+            "src/xenia/ui/shaders/bytecode/metal",
         ])
 
     newest_source = max(get_dir_newest_mtime(gpu_shaders),
@@ -1488,9 +1535,24 @@ def build_shaders(targets=None):
                  if (name.endswith(".glsl") or
                      name.endswith(".hlsl") or
                      name.endswith(".xesl"))]
+    if sys.platform == "win32":
+        all_targets = ["dxbc", "spirv"]
+    elif sys.platform == "darwin":
+        all_targets = ["metal"]
+    else:
+        all_targets = ["spirv"]
+
     if targets is None:
         targets = []
-    all_targets = len(targets) == 0
+    if len(targets) == 0:
+        targets = list(all_targets)
+    else:
+        unsupported_targets = [target for target in targets
+                               if target not in all_targets]
+        if unsupported_targets:
+            print_error("unsupported shader target(s) for this host: "
+                        + ", ".join(sorted(set(unsupported_targets))))
+            return 1
 
     # XeSL ("Xenia Shading Language") means shader files that can be
     # compiled as multiple languages from a single file. Whenever possible,
@@ -1507,7 +1569,7 @@ def build_shaders(targets=None):
     # used in language-specific sources.
 
     # Direct3D DXBC (Windows only).
-    if (all_targets or "dxbc" in targets) and sys.platform == "win32":
+    if "dxbc" in targets:
         print("Building Direct3D 12 Shader Model 5.1 DXBC shaders...")
 
         # Get the FXC path.
@@ -1591,8 +1653,80 @@ def build_shaders(targets=None):
                 print_error(f"failed to compile DXBC shader: {src_path}")
                 return 1
 
+    # Metal MSL.
+    if "metal" in targets:
+        print("Building Metal MSL shaders...")
+
+        use_xcrun = False
+        if not has_bin("metal") or not has_bin("metallib"):
+            if has_bin("xcrun"):
+                use_xcrun = True
+            else:
+                print_error("could not find Metal compiler tools")
+                return 1
+
+        def metal_tool(tool, args):
+            if use_xcrun:
+                return ["xcrun", "-sdk", "macosx", tool] + args
+            return [tool] + args
+
+        module_cache = os.path.join(self_path, "build", "metal_module_cache")
+        os.makedirs(module_cache, exist_ok=True)
+
+        for src_path in src_paths:
+            src_name = os.path.basename(src_path)
+            if (not src_name.endswith(".xesl") or len(src_name) <= 8 or
+                    src_name[-8] != "."):
+                continue
+            if "fxaa" in src_name or "ffx_" in src_name:
+                continue
+            identifier = src_name[:-5].replace(".", "_")
+            stage = identifier[-2:]
+            if stage not in ["cs", "ps", "vs"]:
+                continue
+
+            print(f"- {src_path} > metal")
+            src_dir = os.path.dirname(src_path)
+            out_dir = os.path.join(src_dir, "bytecode/metal")
+            os.makedirs(out_dir, exist_ok=True)
+
+            base_path = os.path.join(out_dir, identifier)
+            air_path = f"{base_path}.air"
+            metallib_path = f"{base_path}.metallib"
+
+            compile_args = [
+                "-x", "metal",
+                "-D", "SHADING_LANGUAGE_MSL_XE=1",
+                "-I", src_dir,
+                f"-fmodules-cache-path={module_cache}",
+            ]
+            cmd = metal_tool("metal", compile_args + [
+                "-c", src_path, "-o", air_path])
+            if subprocess.call(cmd) != 0:  # nosec B603
+                print_error("failed to compile Metal shader")
+                return 1
+            cmd = metal_tool("metallib", [air_path, "-o", metallib_path])
+            if subprocess.call(cmd) != 0:  # nosec B603
+                print_error("failed to link Metal library")
+                return 1
+
+            with open(f"{base_path}.h", "w") as out_file:
+                out_file.write("// Generated with `xb buildshaders`.\n")
+                out_file.write(f"const uint8_t {identifier}_metallib[] = {{")
+                with open(metallib_path, "rb") as mlib:
+                    for i, byte in enumerate(mlib.read()):
+                        out_file.write("\n    " if i % 16 == 0 else " ")
+                        out_file.write(f"0x{byte:02X},")
+                out_file.write("\n};\n")
+
+            for path in [air_path, metallib_path]:
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+
     # Vulkan SPIR-V.
-    if all_targets or "spirv" in targets:
+    if "spirv" in targets:
         print("Building Vulkan SPIR-V shaders...")
 
         # Get the SPIR-V tool paths.
@@ -2081,8 +2215,10 @@ def clean_shader_bytecode():
     bytecode_dirs = [
         "src/xenia/gpu/shaders/bytecode/d3d12_5_1",
         "src/xenia/gpu/shaders/bytecode/vulkan_spirv",
+        "src/xenia/gpu/shaders/bytecode/metal",
         "src/xenia/ui/shaders/bytecode/d3d12_5_1",
         "src/xenia/ui/shaders/bytecode/vulkan_spirv",
+        "src/xenia/ui/shaders/bytecode/metal",
     ]
     for bytecode_dir in bytecode_dirs:
         if os.path.isdir(bytecode_dir):


### PR DESCRIPTION
## Summary
This PR normalizes build plumbing to use split platform variants across premake and CI:

- `Windows-x86_64` / `Windows-ARM64`
- `Linux-x86_64` / `Linux-ARM64`
- `Mac-x86_64` / `Mac-ARM64`

## What changed
- Updated platform filters in root and module `premake5.lua` files.
- Updated `tools/build/scripts/platform_files.lua` to match split platform names.
- Updated build helper scripts (`tools/build/premake.py`, `xenia-build.py`, related Lua helpers).
- Updated CI build plumbing/matrix handling for split platform names.

## Scope
- Build / premake / CI only.
- No intended runtime behavior changes.

## Dependency
Depends on #92 (`[ThirdParty] Update FFmpeg submodule to support x86_64 / ARM64 Platforms`), since FFmpeg source/layout updates are required for clean linking with the split-platform build setup.
