### PR TITLE
[GPU] Add a query sample count saturation cvar for flare tuning

### DIFF
--- a/src/xenia/gpu/gpu_flags.cc
+++ b/src/xenia/gpu/gpu_flags.cc
@@ -94,6 +94,15 @@ DEFINE_int32(occlusion_query_fake_upper_threshold, 100,
              "GPU");
 DEFINE_bool(occlusion_query_log, false,
             "Log occlusion query lifetime and summary stats.", "GPU");
+DEFINE_double(
+    occlusion_query_sample_count_saturation, 1.0,
+    "Compress higher occlusion query sample counts before guest writeback.\n"
+    "This can be useful if effects such as lens flares appear too bright\n"
+    "or too strong.\n"
+    "1.0 = default behavior\n"
+    "0.0 = collapse all nonzero sample counts to 1\n"
+    "Values around 0.90 are a good starting point for subtle tuning.",
+    "GPU");
 
 uint32_t GetGuestVblankRateHz() { return cvars::use_50Hz_mode ? 50 : 60; }
 

--- a/src/xenia/gpu/gpu_flags.h
+++ b/src/xenia/gpu/gpu_flags.h
@@ -37,6 +37,8 @@ DECLARE_int32(occlusion_query_fake_upper_threshold);
 
 DECLARE_bool(occlusion_query_log);
 
+DECLARE_double(occlusion_query_sample_count_saturation);
+
 // Returns the guest vblank rate in Hz (50 for PAL, 60 for NTSC).
 // Based on use_50Hz_mode cvar.
 uint32_t GetGuestVblankRateHz();

--- a/src/xenia/gpu/xenos_zpd_report.h
+++ b/src/xenia/gpu/xenos_zpd_report.h
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "xenia/gpu/gpu_flags.h"
 #include "xenia/gpu/xenos.h"
 
 namespace xe {
@@ -90,6 +91,8 @@ struct XenosZPDReport {
   // only provide a passing count. This is still enough to satisfy most titles.
   static void WriteSampleCount(xenos::xe_gpu_depth_sample_counts* report,
                                uint32_t sample_count) {
+    sample_count = SaturateSampleCount(sample_count);
+
     report->Total_A = sample_count;
     report->Total_B = 0;
     report->ZFail_A = 0;
@@ -98,6 +101,35 @@ struct XenosZPDReport {
     report->ZPass_B = 0;
     report->StencilFail_A = 0;
     report->StencilFail_B = 0;
+  }
+
+  static uint32_t SaturateSampleCount(uint32_t sample_count) {
+    double saturation = std::clamp(
+        static_cast<double>(cvars::occlusion_query_sample_count_saturation),
+        0.0, 1.0);
+
+    if (sample_count == 0 || saturation >= 1.0) {
+      return sample_count;
+    }
+    if (saturation <= 0.0) {
+      return 1;
+    }
+
+    // Preserve lower sample counts and only compress the higher range. A knee
+    // of 32 is a conservative, non-authoritative threshold, acting as a safety
+    // valve for titles using occlusion culling. May need to be revisited.
+    const double knee = 32.0;
+    if (static_cast<double>(sample_count) <= knee) {
+      return sample_count;
+    }
+
+    const double attenuation = 1.0 - saturation;
+    const double exponent = 1.0 - (1.0 - 0.35) * (attenuation * attenuation *
+                                                  (3.0 - 2.0 * attenuation));
+    double saturated_count =
+        knee + std::pow(static_cast<double>(sample_count) - knee, exponent);
+
+    return static_cast<uint32_t>(saturated_count + 0.5);
   }
 
   // Fake mode for titles (425307EC, 4D5309B1) that use QueryBatch and expect


### PR DESCRIPTION
This adds a new cvar, occlusion_query_sample_count_saturation, to let users gently compress higher ZPD sample counts immediately before writeback.

The reason for this is pretty simple: lens flares often show up stronger than on console, even with the ROV counter path.

1.0 = default behavior
0.0 = collapse all nonzero sample counts to 1
0.80 - 0.90 seems to be the sweet spot in the affected titles I've tested.