### PR TITLE
[GPU] Tune strict ZPD retirement and add optional fast ZPD path

### DIFF
--- a/src/xenia/gpu/command_processor.cc
+++ b/src/xenia/gpu/command_processor.cc
@@ -1074,6 +1074,13 @@ bool CommandProcessor::BeginZPDReport(uint32_t report_address) {
   // Bump slot sequence — invalidates pending writes from prior lifetime.
   uint64_t slot_sequence_id = ++zpd_slot_sequences_[slot_base];
 
+  // Clear the cached delta for this address so an orphan END can't carry a
+  // value from the previous lifetime into the new one. A real END will write
+  // the cache again when it resolves.
+  if (cvars::occlusion_query_fast_trust_report) {
+    fast_zpd_report_cached_values_.erase(end_record);
+  }
+
   ReportHandle report_handle = zpd_next_report_handle_++;
   if (report_handle == kInvalidReportHandle) {
     report_handle = zpd_next_report_handle_++;
@@ -1164,7 +1171,10 @@ bool CommandProcessor::EndZPDReport(uint32_t report_address,
     resolved_immediately = true;
     final_value = NormalizeSampleCount(logical.accumulated_samples);
 
-    cached_delta = (final_value == 0 && logical.cached_delta != 0)
+    // Use the current report's result. A cached delta carried over from an
+    // earlier lifetime on this slot should not replace a real zero.
+    cached_delta = cvars::occlusion_query_fast_trust_report ? final_value
+                   : (final_value == 0 && logical.cached_delta != 0)
                        ? logical.cached_delta
                        : final_value;
     logical.cached_delta = cached_delta;
@@ -1198,8 +1208,12 @@ bool CommandProcessor::EndZPDReport(uint32_t report_address,
   if (GetZPDMode() == ZPDMode::kFast) {
     bool write_begin = begin_record && report_record_base &&
                        begin_record != report_record_base;
-    uint32_t speculative =
-        (write_begin && cached_delta == 0) ? 1 : cached_delta;
+    // Promote zero to one only while segments are still pending. Once the real
+    // result is ready, write it as is.
+    bool escape_zero =
+        write_begin && cached_delta == 0 &&
+        (!cvars::occlusion_query_fast_trust_report || !resolved_immediately);
+    uint32_t speculative = escape_zero ? 1 : cached_delta;
     WriteZPDReport(begin_record, report_record_base, begin_value, speculative,
                    write_begin);
   } else if (!resolved_immediately) {

--- a/src/xenia/gpu/command_processor.cc
+++ b/src/xenia/gpu/command_processor.cc
@@ -998,6 +998,11 @@ void CommandProcessor::MakeCoherent() {
 
 void CommandProcessor::PrepareForWait() {
   trace_writer_.Flush();
+  // Only refresh completion if there is a strict ZPD retire pending so
+  // PumpPendingRetire sees the latest progress without adding extra overhead.
+  if (zpd_pending_retire_handle_ != kInvalidReportHandle) {
+    PollCompletedSubmission();
+  }
   // Give strict ZPD a chance to retire an pending report before the guest's
   // loop polls again.
   PumpPendingRetire();
@@ -1093,6 +1098,7 @@ bool CommandProcessor::BeginZPDReport(uint32_t report_address) {
   logical.end_record = end_record;
   logical.begin_value = zpd_slot_values_[slot_base];
   logical.accumulated_samples = 0;
+  logical.last_segment_end_submission = 0;
   logical.pending_segments = 0;
   logical.cached_delta = 0;
   logical.ended = false;
@@ -1289,7 +1295,8 @@ void CommandProcessor::CloseQuerySegment() {
     return;
   }
 
-  if (!CloseZPDQuery(zpd_active_segment_.report_handle)) {
+  uint64_t submission = 0;
+  if (!CloseZPDQuery(zpd_active_segment_.report_handle, submission)) {
     zpd_active_segment_.segment_active = false;
     zpd_active_segment_.segment_pending_begin =
         zpd_active_segment_.logical_active && !zpd_batch_fake_;
@@ -1300,6 +1307,7 @@ void CommandProcessor::CloseQuerySegment() {
   auto it = logical_zpd_reports_.find(zpd_active_segment_.report_handle);
   if (it != logical_zpd_reports_.end()) {
     it->second.pending_segments++;
+    it->second.last_segment_end_submission = submission;
   }
 
   zpd_active_segment_.segment_active = false;
@@ -1362,16 +1370,17 @@ void CommandProcessor::PumpPendingRetire() {
 
   CommandProcessor::ReportHandle handle_to_await = zpd_pending_retire_handle_;
 
-  if (AwaitQueryResolve(handle_to_await)) {
+  auto logical_report = logical_zpd_reports_.find(handle_to_await);
+  if (logical_report == logical_zpd_reports_.end()) {
     zpd_pending_retire_handle_ = kInvalidReportHandle;
     zpd_pending_retire_stalls_ = 0;
     return;
   }
 
-  auto logical_report = logical_zpd_reports_.find(handle_to_await);
-  if (logical_report == logical_zpd_reports_.end()) {
-    // If the report is already gone it retired through another path.
-    // Clear so we don't spin on a handle that no longer exists.
+  uint64_t wait_for_submission =
+      logical_report->second.last_segment_end_submission;
+
+  if (AwaitQueryResolve(handle_to_await, wait_for_submission)) {
     zpd_pending_retire_handle_ = kInvalidReportHandle;
     zpd_pending_retire_stalls_ = 0;
     return;

--- a/src/xenia/gpu/command_processor.h
+++ b/src/xenia/gpu/command_processor.h
@@ -319,6 +319,8 @@ class CommandProcessor {
   virtual void PrepareForWait();
   virtual void ReturnFromWait();
 
+  virtual void PollCompletedSubmission() {}
+
   virtual void OnPrimaryBufferEnd() {}
 
   // TODO(boma): Add tracking for VIZ & EXT queries.
@@ -334,6 +336,8 @@ class CommandProcessor {
   struct ZPDReport {
     // Raw host count across all segments, normalized at retirement.
     uint64_t accumulated_samples = 0;
+    // Submission containing the most recently closed segment's resolve.
+    uint64_t last_segment_end_submission = 0;
     uint64_t slot_sequence_id = 0;
     uint32_t slot_base = 0;
     uint32_t begin_record = 0;
@@ -386,14 +390,20 @@ class CommandProcessor {
     return QueryOpenResult::kFailed;
   }
   // Backend records EndQuery, queues a resolve for the active slot.
-  virtual bool CloseZPDQuery(ReportHandle report_handle) { return false; }
+  virtual bool CloseZPDQuery(ReportHandle report_handle,
+                             uint64_t& out_submission) {
+    return false;
+  }
   // Backend discards the active query without resolving.
   virtual bool DiscardZPDQuery() { return false; }
 
   // Backend drains completed resolves and calls OnZPDQueryResolved for each.
   virtual void PumpQueryResolves() {}
   // Backend waits for all pending segments of report_handle to resolve.
-  virtual bool AwaitQueryResolve(ReportHandle report_handle) { return false; }
+  virtual bool AwaitQueryResolve(ReportHandle report_handle,
+                                 uint64_t wait_for_submission) {
+    return false;
+  }
 
   bool BeginZPDReport(uint32_t report_address);
   bool EndZPDReport(uint32_t report_address, bool guest_forced_end);

--- a/src/xenia/gpu/d3d12/d3d12_command_processor.cc
+++ b/src/xenia/gpu/d3d12/d3d12_command_processor.cc
@@ -146,16 +146,8 @@ void D3D12CommandProcessor::RestoreEdramSnapshot(const void* snapshot) {
   render_target_cache_->RestoreEdramSnapshot(snapshot);
 }
 
-void D3D12CommandProcessor::PrepareForWait() {
-  // Refresh completion data so PumpPendingRetire in the base class sees the
-  // latest GPU progress.
+void D3D12CommandProcessor::PollCompletedSubmission() {
   CheckSubmissionCompletion(0);
-  CommandProcessor::PrepareForWait();
-}
-
-void D3D12CommandProcessor::ReturnFromWait() {
-  CheckSubmissionCompletion(0);
-  CommandProcessor::ReturnFromWait();
 }
 
 bool D3D12CommandProcessor::PushTransitionBarrier(
@@ -5940,7 +5932,8 @@ CommandProcessor::QueryOpenResult D3D12CommandProcessor::OpenZPDQuery(
   return QueryOpenResult::kOpened;
 }
 
-bool D3D12CommandProcessor::CloseZPDQuery(ReportHandle report_handle) {
+bool D3D12CommandProcessor::CloseZPDQuery(ReportHandle report_handle,
+                                          uint64_t& out_submission) {
   if (zpd_active_query_is_rov_) {
     zpd_host_query_pool_->QueueQueryResolve(zpd_active_query_index_, true);
   } else {
@@ -5956,6 +5949,8 @@ bool D3D12CommandProcessor::CloseZPDQuery(ReportHandle report_handle) {
   resolve.uses_rov_counter = zpd_active_query_is_rov_;
   resolve.report_handle = report_handle;
   zpd_resolves_in_flight_.push_back(resolve);
+
+  out_submission = resolve.submission;
 
   zpd_active_query_index_ = UINT32_MAX;
   zpd_active_query_generation_ = 0;
@@ -6018,7 +6013,8 @@ void D3D12CommandProcessor::PumpQueryResolves() {
   }
 }
 
-bool D3D12CommandProcessor::AwaitQueryResolve(ReportHandle report_handle) {
+bool D3D12CommandProcessor::AwaitQueryResolve(ReportHandle report_handle,
+                                              uint64_t wait_for_submission) {
   if (GetZPDMode() == ZPDMode::kFake) {
     return false;
   }
@@ -6028,23 +6024,15 @@ bool D3D12CommandProcessor::AwaitQueryResolve(ReportHandle report_handle) {
 
   PumpQueryResolves();
 
-  // Find the latest submission that has a resolve for this handle.
-  uint64_t wait_for = 0;
-  for (const auto& resolve : zpd_resolves_in_flight_) {
-    if (resolve.report_handle == report_handle) {
-      wait_for = resolve.submission;
-    }
-  }
-
-  if (wait_for == 0) {
-    // No in-flight resolves — check if the report is already done.
+  if (wait_for_submission == 0) {
+    // No segment has closed yet — check if the report is already done.
     auto it = logical_zpd_reports_.find(report_handle);
     return it == logical_zpd_reports_.end() ||
            (it->second.pending_segments == 0 && it->second.ended);
   }
 
   // Ensure the submission is flushed.
-  if (wait_for >= GetCurrentSubmission()) {
+  if (wait_for_submission >= GetCurrentSubmission()) {
     if (!submission_open_) {
       return false;
     }
@@ -6060,8 +6048,9 @@ bool D3D12CommandProcessor::AwaitQueryResolve(ReportHandle report_handle) {
     }
   }
 
-  if (wait_for > GetCompletedSubmission()) {
-    completion_timeline_->AwaitSubmissionAndUpdateCompleted(wait_for);
+  if (wait_for_submission > GetCompletedSubmission()) {
+    completion_timeline_->AwaitSubmissionAndUpdateCompleted(
+        wait_for_submission);
   }
 
   PumpQueryResolves();

--- a/src/xenia/gpu/d3d12/d3d12_command_processor.h
+++ b/src/xenia/gpu/d3d12/d3d12_command_processor.h
@@ -82,8 +82,7 @@ class D3D12CommandProcessor final : public CommandProcessor {
 
   void RestoreEdramSnapshot(const void* snapshot) override;
 
-  void PrepareForWait() override;
-  void ReturnFromWait() override;
+  void PollCompletedSubmission() override;
 
   ui::d3d12::D3D12Provider& GetD3D12Provider() const {
     return *static_cast<ui::d3d12::D3D12Provider*>(
@@ -529,10 +528,12 @@ class D3D12CommandProcessor final : public CommandProcessor {
 
   QueryOpenResult OpenZPDQuery(ReportHandle report_handle,
                                bool can_close_submission) override;
-  bool CloseZPDQuery(ReportHandle report_handle) override;
+  bool CloseZPDQuery(ReportHandle report_handle,
+                     uint64_t& out_submission) override;
   bool DiscardZPDQuery() override;
   void PumpQueryResolves() override;
-  bool AwaitQueryResolve(ReportHandle report_handle) override;
+  bool AwaitQueryResolve(ReportHandle report_handle,
+                         uint64_t wait_for_submission) override;
 
   void RecordZPDResolveBatch();
 

--- a/src/xenia/gpu/gpu_flags.cc
+++ b/src/xenia/gpu/gpu_flags.cc
@@ -94,6 +94,13 @@ DEFINE_int32(occlusion_query_fake_upper_threshold, 100,
              "GPU");
 DEFINE_bool(occlusion_query_log, false,
             "Log occlusion query lifetime and summary stats.", "GPU");
+DEFINE_bool(
+    occlusion_query_fast_trust_report, false,
+    "Prefer the current query report over cached fast mode values.\n"
+    "Can improve occlusion accuracy in fast mode by reducing stale results,\n"
+    "but may also regress occlusion culling in titles that already have\n"
+    "issues with fast mode.",
+    "GPU");
 DEFINE_double(
     occlusion_query_sample_count_saturation, 1.0,
     "Compress higher occlusion query sample counts before guest writeback.\n"

--- a/src/xenia/gpu/gpu_flags.h
+++ b/src/xenia/gpu/gpu_flags.h
@@ -37,6 +37,8 @@ DECLARE_int32(occlusion_query_fake_upper_threshold);
 
 DECLARE_bool(occlusion_query_log);
 
+DECLARE_bool(occlusion_query_fast_trust_report);
+
 DECLARE_double(occlusion_query_sample_count_saturation);
 
 // Returns the guest vblank rate in Hz (50 for PAL, 60 for NTSC).

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -178,16 +178,8 @@ void VulkanCommandProcessor::InitializeShaderStorage(
 
 void VulkanCommandProcessor::RestoreEdramSnapshot(const void* snapshot) {}
 
-void VulkanCommandProcessor::PrepareForWait() {
-  // Refresh completion data so PumpPendingRetire in the base class sees the
-  // latest GPU progress.
+void VulkanCommandProcessor::PollCompletedSubmission() {
   CheckSubmissionCompletionAndDeviceLoss(GetCompletedSubmission());
-  CommandProcessor::PrepareForWait();
-}
-
-void VulkanCommandProcessor::ReturnFromWait() {
-  CheckSubmissionCompletionAndDeviceLoss(GetCompletedSubmission());
-  CommandProcessor::ReturnFromWait();
 }
 
 std::string VulkanCommandProcessor::GetWindowTitleText() const {
@@ -4786,7 +4778,8 @@ CommandProcessor::QueryOpenResult VulkanCommandProcessor::OpenZPDQuery(
   return QueryOpenResult::kOpened;
 }
 
-bool VulkanCommandProcessor::CloseZPDQuery(ReportHandle report_handle) {
+bool VulkanCommandProcessor::CloseZPDQuery(ReportHandle report_handle,
+                                           uint64_t& out_submission) {
   if (!in_render_pass_) {
     XELOGW("ZPD: Split segment requested outside render pass");
     return false;
@@ -4802,6 +4795,8 @@ bool VulkanCommandProcessor::CloseZPDQuery(ReportHandle report_handle) {
   resolve.query_generation = zpd_active_query_generation_;
   resolve.report_handle = report_handle;
   zpd_resolves_in_flight_.push_back(resolve);
+
+  out_submission = resolve.submission;
 
   zpd_active_query_index_ = UINT32_MAX;
   zpd_active_query_generation_ = 0;
@@ -4877,7 +4872,8 @@ void VulkanCommandProcessor::PumpQueryResolves() {
   }
 }
 
-bool VulkanCommandProcessor::AwaitQueryResolve(ReportHandle report_handle) {
+bool VulkanCommandProcessor::AwaitQueryResolve(ReportHandle report_handle,
+                                               uint64_t wait_for_submission) {
   if (GetZPDMode() == ZPDMode::kFake) {
     return false;
   }
@@ -4887,22 +4883,15 @@ bool VulkanCommandProcessor::AwaitQueryResolve(ReportHandle report_handle) {
 
   PumpQueryResolves();
 
-  // Find the latest submission that has a resolve for this handle.
-  uint64_t wait_for = 0;
-  for (const auto& resolve : zpd_resolves_in_flight_) {
-    if (resolve.report_handle == report_handle) {
-      wait_for = resolve.submission;
-    }
-  }
-
-  if (wait_for == 0) {
+  if (wait_for_submission == 0) {
+    // No segment has closed yet — check if the report is already done.
     auto it = logical_zpd_reports_.find(report_handle);
     return it == logical_zpd_reports_.end() ||
            (it->second.pending_segments == 0 && it->second.ended);
   }
 
   // Ensure the submission is flushed.
-  if (wait_for >= GetCurrentSubmission()) {
+  if (wait_for_submission >= GetCurrentSubmission()) {
     if (!submission_open_) {
       return false;
     }
@@ -4920,8 +4909,8 @@ bool VulkanCommandProcessor::AwaitQueryResolve(ReportHandle report_handle) {
     }
   }
 
-  if (wait_for > GetCompletedSubmission()) {
-    completion_timeline_.AwaitSubmissionAndUpdateCompleted(wait_for);
+  if (wait_for_submission > GetCompletedSubmission()) {
+    completion_timeline_.AwaitSubmissionAndUpdateCompleted(wait_for_submission);
   }
 
   PumpQueryResolves();

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.h
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.h
@@ -156,8 +156,7 @@ class VulkanCommandProcessor final : public CommandProcessor {
 
   void RestoreEdramSnapshot(const void* snapshot) override;
 
-  void PrepareForWait() override;
-  void ReturnFromWait() override;
+  void PollCompletedSubmission() override;
 
   ui::vulkan::VulkanDevice* GetVulkanDevice() const {
     return static_cast<const ui::vulkan::VulkanProvider*>(
@@ -484,10 +483,12 @@ class VulkanCommandProcessor final : public CommandProcessor {
 
   QueryOpenResult OpenZPDQuery(ReportHandle report_handle,
                                bool can_close_submission) override;
-  bool CloseZPDQuery(ReportHandle report_handle) override;
+  bool CloseZPDQuery(ReportHandle report_handle,
+                     uint64_t& out_submission) override;
   bool DiscardZPDQuery() override;
   void PumpQueryResolves() override;
-  bool AwaitQueryResolve(ReportHandle report_handle) override;
+  bool AwaitQueryResolve(ReportHandle report_handle,
+                         uint64_t wait_for_submission) override;
 
   void UpdateDynamicState(const draw_util::ViewportInfo& viewport_info,
                           bool primitive_polygonal,


### PR DESCRIPTION
Follow up to the ongoing ZPD work after 127.

Some of the later cleanup was good and logical, but strict mode got modesty slower in the process. This restores a few of the useful ideas from the original PR in a smaller form by caching the resolve submission at query close and tightening up the wait refresh logic.

I'm also adding an optional occlusion_query_fast_trust_report cvar for fast mode, which elects to trust the current report more, which helps correctness in some titles, especially certain UE3 cases, but it is left off by default since I noticed that it regresses a couple games that already have issues with fast.