### PR TITLE
[Vulkan/MoltenVK] Add shader compatibility fallbacks

### DIFF
--- a/src/xenia/gpu/spirv_builder.cc
+++ b/src/xenia/gpu/spirv_builder.cc
@@ -42,7 +42,9 @@ spv::Id SpirvBuilder::createNoContractionUnaryOp(spv::Op op_code,
                                                  spv::Id type_id,
                                                  spv::Id operand) {
   spv::Id result = createUnaryOp(op_code, type_id, operand);
-  addDecoration(result, spv::DecorationNoContraction);
+  if (!allow_contraction_) {
+    addDecoration(result, spv::DecorationNoContraction);
+  }
   return result;
 }
 
@@ -50,7 +52,9 @@ spv::Id SpirvBuilder::createNoContractionBinOp(spv::Op op_code, spv::Id type_id,
                                                spv::Id operand1,
                                                spv::Id operand2) {
   spv::Id result = createBinOp(op_code, type_id, operand1, operand2);
-  addDecoration(result, spv::DecorationNoContraction);
+  if (!allow_contraction_) {
+    addDecoration(result, spv::DecorationNoContraction);
+  }
   return result;
 }
 

--- a/src/xenia/gpu/spirv_builder.h
+++ b/src/xenia/gpu/spirv_builder.h
@@ -29,6 +29,10 @@ class SpirvBuilder : public spv::Builder {
                spv::SpvBuildLogger* logger)
       : spv::Builder(spv_version, user_number, logger) {}
 
+  // When true, createNoContraction* helpers emit plain operations.
+  void SetAllowContraction(bool allow) { allow_contraction_ = allow; }
+  bool AllowsContraction() const { return allow_contraction_; }
+
   // Make public rather than protected.
   using spv::Builder::createSelectionMerge;
 
@@ -188,6 +192,9 @@ class SpirvBuilder : public spv::Builder {
 
     Branch current_branch_ = Branch::kSelection;
   };
+
+ private:
+  bool allow_contraction_ = false;
 };
 
 }  // namespace gpu

--- a/src/xenia/gpu/spirv_shader_translator.cc
+++ b/src/xenia/gpu/spirv_shader_translator.cc
@@ -49,6 +49,13 @@ DEFINE_bool(
     "interpolated values. Requires VK_KHR_fragment_shader_barycentric.",
     "GPU");
 
+DEFINE_bool(
+    spirv_moltenvk_allow_contraction, true,
+    "When translating SPIR-V for MoltenVK, omit NoContraction decorations so "
+    "SPIRV-Cross doesn't emit MSL NoContraction helper wrappers with "
+    "[[clang::optnone]]. Other Vulkan drivers keep NoContraction enabled.",
+    "GPU");
+
 namespace xe {
 namespace gpu {
 
@@ -157,7 +164,10 @@ SpirvShaderTranslator::Features::Features(
       demote_to_helper_invocation(
           vulkan_device->properties().shaderDemoteToHelperInvocation),
       fragment_shader_barycentric(
-          vulkan_device->properties().fragmentShaderBarycentric) {
+          vulkan_device->properties().fragmentShaderBarycentric),
+      allow_float_contraction(cvars::spirv_moltenvk_allow_contraction &&
+                              vulkan_device->properties().driverID ==
+                                  VK_DRIVER_ID_MOLTENVK) {
   // Check for SPIR-V version override from CVAR.
   const std::string& override_version = cvars::spirv_version_override;
   if (override_version == "1.0") {
@@ -307,6 +317,7 @@ void SpirvShaderTranslator::StartTranslation() {
   // TODO(Triang3l): Logger.
   builder_ = std::make_unique<SpirvBuilder>(
       features_.spirv_version, (kSpirvMagicToolId << 16) | 1, nullptr);
+  builder_->SetAllowContraction(features_.allow_float_contraction);
 
   builder_->addCapability(IsSpirvTessEvalShader() ? spv::CapabilityTessellation
                                                   : spv::CapabilityShader);

--- a/src/xenia/gpu/spirv_shader_translator.cc
+++ b/src/xenia/gpu/spirv_shader_translator.cc
@@ -767,15 +767,16 @@ void SpirvShaderTranslator::StartTranslation() {
     id_vector_temp_.push_back(main_rect_list_loop_continue_->getId());
     main_rect_list_loop_vertex_index_ =
         builder_->createOp(spv::OpPhi, type_int_, id_vector_temp_);
+    spv::Id main_rect_list_loop_condition = builder_->createBinOp(
+        spv::OpSLessThan, type_bool_, main_rect_list_loop_vertex_index_,
+        builder_->makeIntConstant(3));
     uint_vector_temp_.clear();
     builder_->createLoopMerge(
         main_rect_list_loop_merge_, main_rect_list_loop_continue_,
         spv::LoopControlDontUnrollMask, uint_vector_temp_);
-    builder_->createConditionalBranch(
-        builder_->createBinOp(spv::OpSLessThan, type_bool_,
-                              main_rect_list_loop_vertex_index_,
-                              builder_->makeIntConstant(3)),
-        &main_rect_list_loop_body, main_rect_list_loop_merge_);
+    builder_->createConditionalBranch(main_rect_list_loop_condition,
+                                      &main_rect_list_loop_body,
+                                      main_rect_list_loop_merge_);
 
     builder_->setBuildPoint(&main_rect_list_loop_body);
     ResetUcodeInvocationStateInMain();

--- a/src/xenia/gpu/spirv_shader_translator.h
+++ b/src/xenia/gpu/spirv_shader_translator.h
@@ -397,6 +397,8 @@ class SpirvShaderTranslator : public ShaderTranslator {
     bool demote_to_helper_invocation;
 
     bool fragment_shader_barycentric;
+
+    bool allow_float_contraction = false;
   };
 
   SpirvShaderTranslator(const Features& features,

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -5935,6 +5935,23 @@ void VulkanCommandProcessor::UpdateSystemConstantValues(
         primitive_processing_result.guest_index_base;
   }
 
+  // Guest-side vertex index count, used for bounds-safe shared-memory loads in
+  // VS expansion (kPointListAsTriangleStrip / kRectangleListAsTriangleStrip)
+  // and in the full 32-bit index DMA load path. Out-of-bounds lanes read 0
+  // instead of random memory, which otherwise produces scattered/skewed
+  // geometry when expansion fans out past the guest draw count.
+  const bool is_vs_expansion_draw =
+      primitive_processing_result.host_vertex_shader_type ==
+          Shader::HostVertexShaderType::kPointListAsTriangleStrip ||
+      primitive_processing_result.host_vertex_shader_type ==
+          Shader::HostVertexShaderType::kRectangleListAsTriangleStrip;
+  const uint32_t vertex_index_count =
+      is_vs_expansion_draw
+          ? primitive_processing_result.guest_draw_vertex_count
+          : primitive_processing_result.host_draw_vertex_count;
+  dirty |= system_constants_.vertex_index_count != vertex_index_count;
+  system_constants_.vertex_index_count = vertex_index_count;
+
   // Index or tessellation edge factor buffer endianness.
   dirty |= system_constants_.vertex_index_endian !=
            primitive_processing_result.host_shader_index_endian;

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -3062,11 +3062,15 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type,
     // compute.
     // Skip unsupported host vertex shader types (but allow tessellation types
     // through - they will be handled in pipeline creation or rejected there if
-    // not fully supported yet).
+    // not fully supported yet). Both AsTriangleStrip fallbacks are needed on
+    // hosts without geometry shader support (MoltenVK / MoltenVK-like); the
+    // SPIR-V translator and pipeline cache both handle them end-to-end.
     if (primitive_processing_result.host_vertex_shader_type !=
             Shader::HostVertexShaderType::kVertex &&
         primitive_processing_result.host_vertex_shader_type !=
             Shader::HostVertexShaderType::kPointListAsTriangleStrip &&
+        primitive_processing_result.host_vertex_shader_type !=
+            Shader::HostVertexShaderType::kRectangleListAsTriangleStrip &&
         !Shader::IsHostVertexShaderTypeDomain(
             primitive_processing_result.host_vertex_shader_type)) {
       return false;

--- a/src/xenia/ui/vulkan/vulkan_device.cc
+++ b/src/xenia/ui/vulkan/vulkan_device.cc
@@ -816,15 +816,22 @@ std::unique_ptr<VulkanDevice> VulkanDevice::CreateIfSupported(
 
   // VK_KHR_fragment_shader_barycentric (#322) /
   // VK_NV_fragment_shader_barycentric (#203).
-  if (ext_KHR_fragment_shader_barycentric ||
-      ext_NV_fragment_shader_barycentric) {
+  // MoltenVK advertises this, but SPIRV-Cross can't translate Xenia's
+  // PerVertexKHR usage to MSL, so leave the shader path on its fallback.
+  const bool driver_is_moltenvk =
+      device->properties_.driverID == VK_DRIVER_ID_MOLTENVK;
+  if ((ext_KHR_fragment_shader_barycentric ||
+       ext_NV_fragment_shader_barycentric) &&
+      !driver_is_moltenvk) {
     if (with_gpu_emulation) {
       XE_UI_VULKAN_FEATURE_2(features_KHR_fragment_shader_barycentric,
                              fragmentShaderBarycentric);
     }
   }
   device->extensions_.ext_KHR_fragment_shader_barycentric =
-      ext_KHR_fragment_shader_barycentric || ext_NV_fragment_shader_barycentric;
+      (ext_KHR_fragment_shader_barycentric ||
+       ext_NV_fragment_shader_barycentric) &&
+      !driver_is_moltenvk;
 
 #undef XE_UI_VULKAN_LIMIT
 #undef XE_UI_VULKAN_ENUM_LIMIT


### PR DESCRIPTION
Summary:
- Allows rectangle VS expansion draws for the no-geometry-shader MoltenVK path.
- Populates vertex_index_count for bounds-safe index loads during expansion draws.
- Disables the barycentric shader path on MoltenVK and omits NoContraction where SPIRV-Cross MSL lowering cannot be post-processed.
- Keeps rectangle loop merge placement valid for SPIR-V validation.

Validation:
- git diff --check origin/edge..xenios/moltenvk-shader-fallbacks