### PR TITLE
[Kernel/POSIX] Queue timer APCs without guest TLS

### DIFF
--- a/src/xenia/kernel/xthread.cc
+++ b/src/xenia/kernel/xthread.cc
@@ -663,11 +663,15 @@ void XThread::LeaveCriticalRegion() {
 
 void XThread::EnqueueApc(uint32_t normal_routine, uint32_t normal_context,
                          uint32_t arg1, uint32_t arg2) {
-  // don't use thread_state_ -> context() ! we're not running on the thread
-  // we're enqueuing to
-  uint32_t success = xboxkrnl::xeNtQueueApcThread(
-      this->handle(), normal_routine, normal_context, arg1, arg2,
-      cpu::ThreadState::Get()->context());
+  // Most APC queue sites run on a guest thread and can use the caller's bound
+  // PPC context. Host timer callbacks may run without a bound guest
+  // ThreadState, so fall back to the target thread context in that case.
+  auto* queue_thread_state = cpu::ThreadState::Get();
+  auto* queue_context = queue_thread_state ? queue_thread_state->context()
+                                           : thread_state_->context();
+  uint32_t success =
+      xboxkrnl::xeNtQueueApcThread(this->handle(), normal_routine,
+                                   normal_context, arg1, arg2, queue_context);
 
   xenia_assert(success == X_STATUS_SUCCESS);
 }


### PR DESCRIPTION
## Summary
- avoid null-dereferencing cpu::ThreadState::Get() when a host timer callback queues an APC
- keep using the caller PPC context for guest-thread APC queue sites
- fall back to the target XThread context only when no caller ThreadState is bound

## Details
XTimer captures the guest callback routine when the timer is set, but the POSIX timer implementation dispatches the stored callback from Xenia's host TimerQueue thread. That host thread is not a guest thread and does not bind cpu::ThreadState TLS, so the old unconditional cpu::ThreadState::Get()->context() path can crash before the APC is inserted.

This keeps the existing XThread::EnqueueApc API shape and narrows the behavior change to the no-bound-caller-context case.

## Validation
- git diff --check origin/edge..HEAD
- local Mass Effect manual repro no longer crashes in the timer APC path in intro video