### PR TITLE
[A64] Fix SHORT_4 unpack lane order

### DIFF
--- a/src/xenia/cpu/backend/a64/a64_seq_vector.cc
+++ b/src/xenia/cpu/backend/a64/a64_seq_vector.cc
@@ -1669,9 +1669,8 @@ struct UNPACK : Sequence<UNPACK, I<OPCODE_UNPACK, V128Op, V128Op>> {
     e.sxtl2(VReg(0).s4, VReg(s).h8);
     LoadV128Const(e, 1, vec128i(0x40400000u), 0);
     e.add(VReg(0).s4, VReg(0).s4, VReg(1).s4);
-    // Reorder {w,z,y,x} → {x,y,z,w}: rev64 then swap halves.
-    e.rev64(VReg(0).s4, VReg(0).s4);                  // {z,w,x,y}
-    e.ext(VReg(0).b16, VReg(0).b16, VReg(0).b16, 8);  // {x,y,z,w}
+    // Reorder the sign-extended pairs into PPC vector word order.
+    e.rev64(VReg(0).s4, VReg(0).s4);
     EmitMagicFloatOverflowCheck(e, d);
   }
   static void EmitUINT_2101010(A64Emitter& e, const EmitArgType& i) {

--- a/src/xenia/cpu/testing/unpack_test.cc
+++ b/src/xenia/cpu/testing/unpack_test.cc
@@ -117,6 +117,29 @@ TEST_CASE("UNPACK_SHORT_2", "[instr]") {
       });
 }
 
+TEST_CASE("UNPACK_SHORT_4", "[instr]") {
+  TestFunction test([](HIRBuilder& b) {
+    StoreVR(b, 3, b.Unpack(LoadVR(b, 4), PACK_TYPE_SHORT_4));
+    b.Return();
+  });
+  test.Run([](PPCContext* ctx) { ctx->v[4] = vec128i(0); },
+           [](PPCContext* ctx) {
+             auto result = ctx->v[3];
+             REQUIRE(result ==
+                     vec128i(0x40400000, 0x40400000, 0x40400000, 0x40400000));
+           });
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->v[4] = vec128i(0xCDCDCDCD, 0xCDCDCDCD, 0x512E2A47, 0x568EE95B);
+      },
+      [](PPCContext* ctx) {
+        auto result = ctx->v[3];
+        // A64 must preserve the two 64-bit result halves in this order.
+        REQUIRE(result ==
+                vec128i(0x4040512E, 0x40402A47, 0x4040568E, 0x403FE95B));
+      });
+}
+
 TEST_CASE("UNPACK_UINT_2101010", "[instr]") {
   TestFunction test([](HIRBuilder& b) {
     StoreVR(b, 3, b.Unpack(LoadVR(b, 4), PACK_TYPE_UINT_2101010));


### PR DESCRIPTION
A64's PACK_TYPE_SHORT_4 unpack path sign-extends the upper 64 bits of the source vector and then reorders the resulting 32-bit lanes into PPC vector word order. The existing sequence performed rev64 followed by ext(..., 8). That final ext rotated the result by one 64-bit half, producing the right four values in the wrong half order.

This fixes A64 visual and controller input bugs observed in Halo 3, Halo 3: ODST, Halo: Reach, Halo 4, and Nier. In the Halo 3 trace, the bad lane order showed up through vupkd3d128 type 4: x64 produced
[4040512E 40402A47 4040568E 403FE95B], while A64 produced [4040568E 403FE95B 4040512E 40402A47]. Removing the extra ext keeps the pair reorder but avoids the half swap, matching the x64 result and the PPC-visible vector layout.

Add a direct UNPACK_SHORT_4 CPU backend test using distinct packed short lanes. The old A64 sequence fails this test with the same half-swapped output, while the fixed sequence passes. This keeps the coverage independent of the generated PPC corpus and skip list while still exercising the backend codegen that vupkd3d128 lowers to.