### PR TITLE
Add linux-arm64 AppImage build target

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,6 +56,12 @@ jobs:
           name: xenia_edge_linux
           path: linux_artifacts
 
+      - name: Download Linux arm64 artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: xenia_edge_linux_arm64
+          path: linux_arm64_artifacts
+
       - name: Download Windows artifacts
         uses: actions/download-artifact@v8
         with:
@@ -132,6 +138,8 @@ jobs:
           cd linux_artifacts
           # For Linux, just rename the AppImage (no need to zip a single file)
           mv xenia_edge.AppImage ../xenia_edge_linux.AppImage
+          cd ../linux_arm64_artifacts
+          mv xenia_edge.AppImage ../xenia_edge_linux_arm64.AppImage
           cd ../windows_artifacts
           7z a ../xenia_edge_windows.zip * -xr!'*.pdb' -mx9 -bb3
           cd ..
@@ -159,6 +167,7 @@ jobs:
 
           # Create release
           gh release create $tag \
-            xenia_edge_linux.AppImage xenia_edge_windows.zip \
+            xenia_edge_linux.AppImage xenia_edge_linux_arm64.AppImage \
+            xenia_edge_windows.zip \
             xenia_edge_macos.dmg \
             --target $GITHUB_SHA -t "xenia_edge" --notes-file release_notes.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,24 @@ jobs:
         run: ./xenia-build.py lint --all
 
   build-linux:
-    name: Build Linux
+    name: Build Linux ${{ matrix.arch }}
     needs: lint
     # Build on the oldest supported LTS so the AppImage's glibc floor (taken from
-    # the build host) stays low enough for Ubuntu 22.04 / Debian 12 users.
-    runs-on: ubuntu-22.04
+    # the build host) stays low enough for Ubuntu 22.04 / Debian 12 users. The
+    # arm64 leg uses GitHub's native aarch64 runner so there's no cross-compile.
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-22.04
+            linuxdeploy_arch: x86_64
+            artifact: xenia_edge_linux
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+            linuxdeploy_arch: aarch64
+            artifact: xenia_edge_linux_arm64
     steps:
       - uses: actions/checkout@v6
         with:
@@ -35,9 +48,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/linuxdeploy
-          key: ${{ runner.os }}-linuxdeploy-tools
+          key: ${{ runner.os }}-${{ runner.arch }}-linuxdeploy-tools
           restore-keys: |
-            ${{ runner.os }}-linuxdeploy-
+            ${{ runner.os }}-${{ runner.arch }}-linuxdeploy-
 
       - name: Cache Slang
         id: cache-slang
@@ -71,8 +84,8 @@ jobs:
           # Download linuxdeploy if not cached.
           if [ '${{ steps.cache-linuxdeploy.outputs.cache-hit }}' != 'true' ]; then
             mkdir -p ~/linuxdeploy
-            wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -O ~/linuxdeploy/linuxdeploy
-            wget -q https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage -O ~/linuxdeploy/linuxdeploy-plugin-appimage
+            wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${{ matrix.linuxdeploy_arch }}.AppImage -O ~/linuxdeploy/linuxdeploy
+            wget -q https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-${{ matrix.linuxdeploy_arch }}.AppImage -O ~/linuxdeploy/linuxdeploy-plugin-appimage
             chmod +x ~/linuxdeploy/linuxdeploy ~/linuxdeploy/linuxdeploy-plugin-appimage
           fi
           echo "$HOME/linuxdeploy" >> $GITHUB_PATH
@@ -151,7 +164,7 @@ jobs:
         if: steps.prepare_artifacts.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
-          name: xenia_edge_linux
+          name: ${{ matrix.artifact }}
           path: artifacts/release
           if-no-files-found: error
 


### PR DESCRIPTION
## What

Adds a linux-arm64 (aarch64) AppImage as a release build target so future releases ship an Arm build alongside the existing x86_64 Linux AppImage.

## How

- **`build.yml`**: Turned the `build-linux` job into an arch matrix.
  - **x86_64** leg keeps running on `ubuntu-22.04` and uploads the existing `xenia_edge_linux` artifact (unchanged behavior).
  - **arm64** leg runs on GitHub's native `ubuntu-22.04-arm` runner — no cross-compile — pulls the `aarch64` linuxdeploy tools, and uploads a new `xenia_edge_linux_arm64` artifact.
  - `fail-fast: false` so a problem on one arch doesn't cancel the other.
  - Scoped the linuxdeploy cache key by `runner.arch` so the two legs don't overwrite each other's cached tools. (The Slang cache key already included arch.)
- **`CI.yml`**: The `release` job now downloads the arm64 artifact and attaches `xenia_edge_linux_arm64.AppImage` to each release, next to the existing Linux/Windows/macOS assets.

## Notes for reviewers

- Staying on the 22.04 runner keeps the AppImage glibc floor the same for Arm as it is for x86_64 (Ubuntu 22.04 / Debian 12).
- Verified locally by YAML-parsing both workflow files and reviewing the diff; the arm64 leg gets its first real run on CI once this lands.