### PR TITLE
[APP] Switch compatibility data source

### DIFF
--- a/src/xenia/app/CMakeLists.txt
+++ b/src/xenia/app/CMakeLists.txt
@@ -204,9 +204,9 @@ endif()
 xe_embed_binary_assets(xenia-app
     "${PROJECT_SOURCE_DIR}/assets/icons" icons)
 
-# Bake game-compat data (canary.json from xenia-manager/database).
+# Bake game-compat data (compatibility_data.json from xenia-canary/game-compatibility).
 xe_embed_compressed_bundle(xenia-app
-    "${PROJECT_SOURCE_DIR}/build/data_repos/xenia-manager-database/data/game-compatibility"
+    "${PROJECT_SOURCE_DIR}/build/data_repos/game-compatibility"
     game_compat)
 
 # Bake the x360db title database (games.json from xenia-manager/x360db).

--- a/src/xenia/app/game_compat_db.cc
+++ b/src/xenia/app/game_compat_db.cc
@@ -53,9 +53,11 @@ const std::unordered_map<uint32_t, CompatState>& GetCompatIndex() {
       XELOGE("CompatDb: bundle decompress failed");
       return map;
     }
-    // Merge canary and stable: most-optimistic state across all sources wins.
+    // When multiple files are present (fallback) merge with most-optimistic
+    // state across all sources winning.
     bundle.ForEach([&](std::string_view name, std::string_view data) {
-      if (name != "canary.json" && name != "stable.json") {
+      if (name != "compatibility_data.json" && name != "canary.json" &&
+          name != "stable.json") {
         return;
       }
       rapidjson::Document doc;

--- a/src/xenia/app/game_compat_db.cc
+++ b/src/xenia/app/game_compat_db.cc
@@ -44,9 +44,9 @@ CompatState ParseState(std::string_view s) {
   return CompatState::kUnknown;
 }
 
-const std::unordered_map<uint32_t, CompatState>& GetCompatIndex() {
-  static const std::unordered_map<uint32_t, CompatState> index = []() {
-    std::unordered_map<uint32_t, CompatState> map;
+const std::unordered_map<uint32_t, CompatEntry>& GetCompatIndex() {
+  static const std::unordered_map<uint32_t, CompatEntry> index = []() {
+    std::unordered_map<uint32_t, CompatEntry> map;
     xe::EmbeddedBundle bundle(xe::embedded_bundle_game_compat::kBundleData,
                               xe::embedded_bundle_game_compat::kBundleSize);
     if (!bundle.ok()) {
@@ -86,8 +86,15 @@ const std::unordered_map<uint32_t, CompatState>& GetCompatIndex() {
         CompatState s = ParseState(std::string_view(
             state_it->value.GetString(), state_it->value.GetStringLength()));
         auto& slot = map[title_id];
-        if (static_cast<uint8_t>(s) > static_cast<uint8_t>(slot)) {
-          slot = s;
+        if (static_cast<uint8_t>(s) > static_cast<uint8_t>(slot.state)) {
+          slot.state = s;
+        }
+        if (slot.url.empty()) {
+          auto url_it = entry.FindMember("url");
+          if (url_it != entry.MemberEnd() && url_it->value.IsString()) {
+            slot.url.assign(url_it->value.GetString(),
+                            url_it->value.GetStringLength());
+          }
         }
       }
     });
@@ -105,7 +112,7 @@ CompatState GetCompatState(uint32_t title_id) {
   const auto& idx = GetCompatIndex();
   auto it = idx.find(title_id);
   if (it != idx.end()) {
-    return it->second;
+    return it->second.state;
   }
   // No direct entry: the game may be tracked under a different release's id.
   // Fall back to the most optimistic compat state among the x360db sibling
@@ -116,13 +123,35 @@ CompatState GetCompatState(uint32_t title_id) {
     for (uint32_t alias : *group) {
       auto alias_it = idx.find(alias);
       if (alias_it != idx.end() &&
-          static_cast<uint8_t>(alias_it->second) > static_cast<uint8_t>(best)) {
-        best = alias_it->second;
+          static_cast<uint8_t>(alias_it->second.state) >
+              static_cast<uint8_t>(best)) {
+        best = alias_it->second.state;
       }
     }
     return best;
   }
   return CompatState::kUnknown;
+}
+
+std::string GetCompatUrl(uint32_t title_id) {
+  if (title_id == 0) {
+    return {};
+  }
+  const auto& idx = GetCompatIndex();
+  auto it = idx.find(title_id);
+  if (it != idx.end() && !it->second.url.empty()) {
+    return it->second.url;
+  }
+  const std::vector<uint32_t>* group = GetTitleIdGroup(title_id);
+  if (group) {
+    for (uint32_t alias : *group) {
+      auto alias_it = idx.find(alias);
+      if (alias_it != idx.end() && !alias_it->second.url.empty()) {
+        return alias_it->second.url;
+      }
+    }
+  }
+  return {};
 }
 
 std::string CompatSearchQuery(uint32_t title_id) {

--- a/src/xenia/app/game_compat_db.h
+++ b/src/xenia/app/game_compat_db.h
@@ -25,7 +25,15 @@ enum class CompatState : uint8_t {
   kPlayable,
 };
 
+struct CompatEntry {
+  CompatState state = CompatState::kUnknown;
+  std::string url;
+};
+
 CompatState GetCompatState(uint32_t title_id);
+
+// Issue URL from the compatibility database for a title, or empty if absent.
+std::string GetCompatUrl(uint32_t title_id);
 
 // GitHub issue-search query fragment for a title. Returns the title id, or all
 // sibling ids (x360db alternative ids) OR'd in parentheses when present.

--- a/src/xenia/ui/game_list_panel_wx.cc
+++ b/src/xenia/ui/game_list_panel_wx.cc
@@ -1062,16 +1062,21 @@ void GameListPanel::OnItemContextMenu(wxDataViewEvent& event) {
     auto* compat = new wxMenu;
     auto* canary = compat->Append(wxID_ANY, _("Canary"));
     auto* master = compat->Append(wxID_ANY, _("Master"));
-    // Search every title id the game is known by, so a release tracked under a
-    // sibling id is still found.
+    // Use the issue URL from the compat database when available; fall back to
+    // a GitHub issue-search query for titles not yet tracked.
+    std::string compat_url = GetCompatUrl(entry.title_id);
     std::string compat_query = CompatSearchQuery(entry.title_id);
     menu.Bind(
         wxEVT_MENU,
-        [compat_query](wxCommandEvent&) {
-          xe::LaunchWebBrowser(fmt::format(
-              "https://github.com/xenia-canary/game-compatibility/issues"
-              "?q=is%3Aissue+is%3Aopen+{}",
-              compat_query));
+        [compat_url, compat_query](wxCommandEvent&) {
+          if (!compat_url.empty()) {
+            xe::LaunchWebBrowser(compat_url);
+          } else {
+            xe::LaunchWebBrowser(fmt::format(
+                "https://github.com/xenia-canary/game-compatibility/issues"
+                "?q=is%3Aissue+is%3Aopen+{}",
+                compat_query));
+          }
         },
         canary->GetId());
     menu.Bind(

--- a/xenia-build.py
+++ b/xenia-build.py
@@ -19,6 +19,7 @@ import sys
 import stat
 import tarfile
 import time
+from urllib.parse import urlparse
 import urllib.request
 import zipfile
 import enum
@@ -530,27 +531,34 @@ def fetch_data_repos():
     # Falls back to xenia-manager/database if the download fails.
     compat_dir = os.path.join(data_dir, "game-compatibility")
     os.makedirs(compat_dir, exist_ok=True)
-    compat_url = "https://github.com/xenia-canary/game-compatibility/releases/download/game-compatibility/compatibility_data.json"
+    compat_url = (
+        "https://github.com/xenia-canary/game-compatibility/releases/download/"
+        "game-compatibility/compatibility_data.json"
+    )
+    compat_url_parsed = urlparse(compat_url)
     compat_path = os.path.join(compat_dir, "compatibility_data.json")
     print("  - downloading compatibility_data.json...")
     max_attempts = 3
     downloaded = False
-    for attempt in range(1, max_attempts + 1):
-        tmp_path = compat_path + ".tmp"
-        try:
-            urllib.request.urlretrieve(compat_url, tmp_path)
-            os.replace(tmp_path, compat_path)
-            downloaded = True
-            break
-        except (urllib.error.URLError, OSError) as e:
-            if os.path.exists(tmp_path):
-                os.remove(tmp_path)
-            if attempt < max_attempts:
-                print(f"  - attempt {attempt}/{max_attempts} failed: {e}, retrying...")
-                time.sleep(2 * attempt)
-            else:
-                print_warning(f"compatibility_data.json download failed after "
-                              f"{max_attempts} attempts: {e}")
+    if compat_url_parsed.scheme != "https":
+        print_warning("compatibility_data URL is not valid, skipping download")
+    else:
+        for attempt in range(1, max_attempts + 1):
+            tmp_path = compat_path + ".tmp"
+            try:
+                urllib.request.urlretrieve(compat_url, tmp_path)
+                os.replace(tmp_path, compat_path)
+                downloaded = True
+                break
+            except (urllib.error.URLError, OSError) as e:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+                if attempt < max_attempts:
+                    print(f"  - attempt {attempt}/{max_attempts} failed: {e}, retrying...")
+                    time.sleep(2 * attempt)
+                else:
+                    print_warning(f"compatibility_data.json download failed after "
+                                f"{max_attempts} attempts: {e}")
     if not downloaded:
         # Fall back to xenia-manager/database compatibility data.
         fallback_src = os.path.join(data_dir, "xenia-manager-database",

--- a/xenia-build.py
+++ b/xenia-build.py
@@ -13,11 +13,12 @@ from glob import glob
 from json import loads as jsonloads
 import os
 import platform
-from shutil import rmtree, which as shutil_which
+from shutil import rmtree, copy2, which as shutil_which
 import subprocess
 import sys
 import stat
 import tarfile
+import time
 import urllib.request
 import zipfile
 import enum
@@ -524,6 +525,45 @@ def fetch_data_repos():
                 repo["url"],
                 repo_path,
             ])
+
+    # Download compatibility data from xenia-canary/game-compatibility release.
+    # Falls back to xenia-manager/database if the download fails.
+    compat_dir = os.path.join(data_dir, "game-compatibility")
+    os.makedirs(compat_dir, exist_ok=True)
+    compat_url = "https://github.com/xenia-canary/game-compatibility/releases/download/game-compatibility/compatibility_data.json"
+    compat_path = os.path.join(compat_dir, "compatibility_data.json")
+    print(f"  - downloading compatibility_data.json...")
+    max_attempts = 3
+    downloaded = False
+    for attempt in range(1, max_attempts + 1):
+        tmp_path = compat_path + ".tmp"
+        try:
+            urllib.request.urlretrieve(compat_url, tmp_path)
+            os.replace(tmp_path, compat_path)
+            downloaded = True
+            break
+        except (urllib.error.URLError, OSError) as e:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            if attempt < max_attempts:
+                print(f"  - attempt {attempt}/{max_attempts} failed: {e}, retrying...")
+                time.sleep(2 * attempt)
+            else:
+                print_warning(f"compatibility_data.json download failed after "
+                              f"{max_attempts} attempts: {e}")
+    if not downloaded:
+        # Fall back to xenia-manager/database compatibility data.
+        fallback_src = os.path.join(data_dir, "xenia-manager-database",
+                                    "data", "game-compatibility")
+        if os.path.isdir(fallback_src):
+            for f in os.listdir(fallback_src):
+                copy2(os.path.join(fallback_src, f),
+                       os.path.join(compat_dir, f))
+            print(f"  - using xenia-manager/database compatibility data as fallback")
+        else:
+            print_error("no compatibility data available (download failed and "
+                        "xenia-manager/database fallback not found)")
+            sys.exit(1)
 
 
 def get_cc(cc=None):

--- a/xenia-build.py
+++ b/xenia-build.py
@@ -532,7 +532,7 @@ def fetch_data_repos():
     os.makedirs(compat_dir, exist_ok=True)
     compat_url = "https://github.com/xenia-canary/game-compatibility/releases/download/game-compatibility/compatibility_data.json"
     compat_path = os.path.join(compat_dir, "compatibility_data.json")
-    print(f"  - downloading compatibility_data.json...")
+    print("  - downloading compatibility_data.json...")
     max_attempts = 3
     downloaded = False
     for attempt in range(1, max_attempts + 1):
@@ -559,7 +559,7 @@ def fetch_data_repos():
             for f in os.listdir(fallback_src):
                 copy2(os.path.join(fallback_src, f),
                        os.path.join(compat_dir, f))
-            print(f"  - using xenia-manager/database compatibility data as fallback")
+            print("  - using xenia-manager/database compatibility data as fallback")
         else:
             print_error("no compatibility data available (download failed and "
                         "xenia-manager/database fallback not found)")


### PR DESCRIPTION
Switches the compatibility data pipeline from cloning `xenia-manager/database` at build time to downloading compatibility_data.json from the `xenia-canary/game-compatibility` GitHub release.

- [x] Build script downloads `compatibility_data.json` from the GitHub release URL with 3-attempt retry and backoff, falling back to xenia-manager/database if the download fails
- [x] Runtime parser accepts `compatibility_data.json` alongside the fallback `canary.json`/`stable.json`
- [x] Canary compatibility menu item now opens the issue URL from the compatibility database directly, falling back to a GitHub search query when no URL is available

