### PR TITLE
add memfd fallback and remove gate check

### DIFF
--- a/src/xenia/base/memory_posix.cc
+++ b/src/xenia/base/memory_posix.cc
@@ -434,6 +434,37 @@ FileMappingHandle CreateFileMappingHandle(const std::filesystem::path& path,
   return ret;
 #else
   auto full_path = "/" / path;
+#if XE_PLATFORM_LINUX
+  // If /dev/shm is mounted noexec fallback to memfd
+  {
+    std::ifstream mounts("/proc/mounts");
+    std::string line;
+    while (std::getline(mounts, line)) {
+      if (line.find("/dev/shm") != std::string::npos &&
+          line.find("noexec") != std::string::npos) {
+#ifndef MFD_CLOEXEC
+#define MFD_CLOEXEC 0x0001U
+#endif
+#ifndef MFD_EXEC
+#define MFD_EXEC 0x0010U
+#endif
+        int memfd = memfd_create(path.c_str(), MFD_CLOEXEC | MFD_EXEC);
+        if (memfd < 0 && errno == EINVAL) {
+          memfd = memfd_create(path.c_str(), MFD_CLOEXEC);
+        }
+        if (memfd < 0 || ftruncate(memfd, length) < 0) {
+          XELOGE("memfd fallback for {} failed: {} ({})", path.string(),
+                 strerror(errno), errno);
+          if (memfd >= 0) {
+            close(memfd);
+          }
+          return kFileMappingHandleInvalid;
+        }
+        return memfd;
+      }
+    }
+  }
+#endif  // XE_PLATFORM_LINUX
   int ret = shm_open(full_path.c_str(), oflag, 0777);
   if (ret < 0) {
     XELOGE("shm_open({}) failed: {} ({})", full_path.string(), strerror(errno),

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -12,9 +12,6 @@
 #include "xenia/emulator.h"
 
 #include <algorithm>
-#if XE_PLATFORM_LINUX
-#include <fstream>
-#endif
 #include "config.h"
 #include "third_party/fmt/include/fmt/format.h"
 #include "xenia/apu/audio_system.h"
@@ -280,31 +277,6 @@ X_STATUS Emulator::Setup(
   // Before we can set thread affinity we must enable the process to use all
   // logical processors.
   xe::threading::EnableAffinityConfiguration();
-
-#if XE_PLATFORM_LINUX
-  // Check if /dev/shm is mounted with noexec. The code cache uses shm_open
-  // with PROT_EXEC, which will fail with EPERM on noexec tmpfs mounts.
-  {
-    std::ifstream mounts("/proc/mounts");
-    std::string line;
-    while (std::getline(mounts, line)) {
-      if (line.find("/dev/shm") != std::string::npos &&
-          line.find("noexec") != std::string::npos) {
-        XELOGE(
-            "/dev/shm is mounted with noexec, which prevents the code cache "
-            "from allocating executable memory. Please remount it with: "
-            "sudo mount -o remount,exec /dev/shm");
-        xe::ShowSimpleMessageBox(
-            xe::SimpleMessageBoxType::Error,
-            "/dev/shm is mounted with noexec, which prevents Xenia from "
-            "allocating executable memory for the code cache.\n\n"
-            "Please remount it with:\n"
-            "  sudo mount -o remount,exec /dev/shm");
-        return X_STATUS_UNSUCCESSFUL;
-      }
-    }
-  }
-#endif
 
   XELOGI("{}: Initializing Memory...", __func__);
   // Create memory system first, as it is required for other systems.


### PR DESCRIPTION
Inside docker environments shm is mounted noexec and I ran into this trying to embed into a container env. This falls back to memfd for memory mapping instead of a hard block. I tested a couple titles I do not have any bugs to report, they run the same as shm_open. 

Let me know if you need anymore information. 