### PR TITLE
[APU] Emit silence instead of stalling on XMA hard decode errors (fixes LEGO LOTR intro freeze)

### DIFF
--- a/src/xenia/apu/xma_context_new.cc
+++ b/src/xenia/apu/xma_context_new.cc
@@ -261,6 +261,7 @@ void XmaContextNew::ClearLocked(XMA_CONTEXT_DATA* data) {
   current_frame_remaining_subframes_ = 0;
   loop_frame_output_limit_ = 0;
   loop_start_skip_pending_ = false;
+  consecutive_decode_errors_ = 0;
 }
 
 void XmaContextNew::Disable() { set_is_enabled(false); }
@@ -582,7 +583,9 @@ void XmaContextNew::Decode(XMA_CONTEXT_DATA* data) {
 
   PrepareDecoder(data->sample_rate, bool(data->is_stereo));
   PreparePacket(packet_info.current_frame_size_, padding_start);
-  if (DecodePacket(av_context_, av_packet_, av_frame_)) {
+  const int decode_result = DecodePacket(av_context_, av_packet_, av_frame_);
+  if (decode_result == 0) {
+    consecutive_decode_errors_ = 0;
     // dump_raw(av_frame_, id());
     ConvertFrame(reinterpret_cast<const uint8_t**>(&av_frame_->data),
                  bool(data->is_stereo), raw_frame_.data());
@@ -613,6 +616,18 @@ void XmaContextNew::Decode(XMA_CONTEXT_DATA* data) {
       }
       loop_start_skip_pending_ = false;
     }
+  } else if (decode_result < 0) {
+    // Hard decode error (corrupt or unsupported frame, e.g. ffmpeg rejecting
+    // num_vec_coeffs). Emit one frame of silence instead of producing no
+    // output: games hard-sync cutscenes and streamed audio to XMA output and
+    // stall forever if the stream stops advancing (LEGO LOTR intro cutscene).
+    // raw_frame_ was already zero-filled above. Flush the codec so a corrupt
+    // frame can't poison the decode of the following valid frames.
+    consecutive_decode_errors_++;
+    avcodec_flush_buffers(av_context_);
+    current_frame_remaining_subframes_ = 4 << data->is_stereo;
+    loop_frame_output_limit_ = 0;
+    loop_start_skip_pending_ = false;
   }
 
   // Compute where to go next.
@@ -930,29 +945,44 @@ void XmaContextNew::PreparePacket(const uint32_t frame_size,
   xma_frame_[0] = ((frame_padding & 7) << 5) | ((padding_end & 7) << 2);
 }
 
-bool XmaContextNew::DecodePacket(AVCodecContext* av_context,
-                                 const AVPacket* av_packet, AVFrame* av_frame) {
+int XmaContextNew::DecodePacket(AVCodecContext* av_context,
+                                const AVPacket* av_packet, AVFrame* av_frame) {
+  // Rate-limit error logging: streams with systematically undecodable frames
+  // (e.g. LEGO LOTR intro voice track) would otherwise flood the log with
+  // thousands of identical lines.
+  const bool log_error =
+      consecutive_decode_errors_ < 8 || (consecutive_decode_errors_ % 512) == 0;
+
   auto ret = avcodec_send_packet(av_context, av_packet);
   if (ret < 0) {
-    char errbuf[AV_ERROR_MAX_STRING_SIZE];
-    av_strerror(ret, errbuf, sizeof(errbuf));
-    XELOGE("XmaContext {}: Error sending packet for decoding: {} ({})", id(),
-           errbuf, ret);
-    return false;
+    if (log_error) {
+      char errbuf[AV_ERROR_MAX_STRING_SIZE];
+      av_strerror(ret, errbuf, sizeof(errbuf));
+      XELOGE(
+          "XmaContext {}: Error sending packet for decoding: {} ({}) "
+          "[{} consecutive errors]",
+          id(), errbuf, ret, consecutive_decode_errors_ + 1);
+    }
+    return -1;
   }
   ret = avcodec_receive_frame(av_context, av_frame);
 
   if (ret == AVERROR(EAGAIN)) {
     // Codec needs more input before producing output (e.g. first frame warmup).
-    return false;
+    return 1;
   }
   if (ret < 0) {
-    char errbuf[AV_ERROR_MAX_STRING_SIZE];
-    av_strerror(ret, errbuf, sizeof(errbuf));
-    XELOGE("XmaContext {}: Error during decoding: {} ({})", id(), errbuf, ret);
-    return false;
+    if (log_error) {
+      char errbuf[AV_ERROR_MAX_STRING_SIZE];
+      av_strerror(ret, errbuf, sizeof(errbuf));
+      XELOGE(
+          "XmaContext {}: Error during decoding: {} ({}) "
+          "[{} consecutive errors]",
+          id(), errbuf, ret, consecutive_decode_errors_ + 1);
+    }
+    return -1;
   }
-  return true;
+  return 0;
 }
 
 void XmaContextNew::StoreContextMerged(const XMA_CONTEXT_DATA& data,

--- a/src/xenia/apu/xma_context_new.h
+++ b/src/xenia/apu/xma_context_new.h
@@ -114,8 +114,10 @@ class XmaContextNew : public XmaContext {
 
   RingBuffer PrepareOutputRingBuffer(XMA_CONTEXT_DATA* data);
 
-  bool DecodePacket(AVCodecContext* av_context, const AVPacket* av_packet,
-                    AVFrame* av_frame);
+  // Returns 0 on success (frame available), 1 when the codec needs more
+  // input (EAGAIN), -1 on a hard decode error.
+  int DecodePacket(AVCodecContext* av_context, const AVPacket* av_packet,
+                   AVFrame* av_frame);
 
   // Re-reads context from guest memory and merges only decoder-owned fields,
   // preserving any game modifications made during decoding.
@@ -138,6 +140,9 @@ class XmaContextNew : public XmaContext {
   // When true, the next decoded frame should skip leading subframes per
   // loop_subframe_skip (loop start adjustment).
   bool loop_start_skip_pending_ = false;
+  // Consecutive hard decode failures on this context, used to rate-limit
+  // error logging while the stream carries undecodable frames.
+  uint32_t consecutive_decode_errors_ = 0;
 };
 
 }  // namespace apu

--- a/src/xenia/apu/xma_decoder.cc
+++ b/src/xenia/apu/xma_decoder.cc
@@ -9,6 +9,9 @@
 
 #include "xenia/apu/xma_decoder.h"
 
+#include <mutex>
+#include <string>
+
 #include "xenia/apu/xma_context.h"
 #include "xenia/apu/xma_context_fake.h"
 #include "xenia/apu/xma_context_master.h"
@@ -131,6 +134,26 @@ void av_log_callback(void* avcl, int level, const char* fmt, va_list va) {
 
   StringBuffer buff;
   buff.AppendVarargs(fmt, va);
+
+  // Suppress runs of identical messages: a stream with systematically
+  // undecodable frames otherwise floods the log with thousands of identical
+  // per-frame errors. Log the first few, then one out of every 512.
+  {
+    static std::mutex log_dedup_mutex;
+    static std::string last_message;
+    static uint64_t repeat_count = 0;
+    std::lock_guard<std::mutex> lock(log_dedup_mutex);
+    if (buff.to_string_view() == last_message) {
+      repeat_count++;
+      if (repeat_count >= 8 && (repeat_count % 512) != 0) {
+        return;
+      }
+    } else {
+      last_message = buff.to_string();
+      repeat_count = 0;
+    }
+  }
+
   xe::logging::AppendLogLineFormat(LogSrc::Apu, log_level, level_char,
                                    "ffmpeg: {}", buff.to_string_view());
 }


### PR DESCRIPTION
## Summary

LEGO The Lord of the Rings (5752081D) freezes permanently ~20 seconds into its opening in-engine cutscene on every XMA decoder backend. This PR makes `XmaContextNew` substitute silence for frames the decoder hard-rejects, so audio-synced game logic keeps advancing instead of deadlocking. Together with has207/FFmpeg#1 (required, see below) the game becomes playable: the intro cutscene plays through — the undecodable stretch is heard as ~0.5 s of silence/noise — and gameplay is reachable.

## Step-by-step diagnosis

1. **Symptom**: the game freezes at the same cutscene timestamp every run, but is not fully hung — shader-animated candle flames keep moving and background music keeps playing, so the emulator keeps presenting while game logic stalls. Reproduced identically on D3D12 and Vulkan, ruling out the GPU backends.
2. **Log evidence** (`xma_decoder = "new"`): thousands of `ffmpeg: num_vec_coeffs 160/164 is too large` lines per second from the XMA guest thread, with the guest frame counter frozen, until the process is killed.
3. **Decoder comparison**: every backend stalls on the same stream, each at the point where its implementation stops producing output — `fake` (decodes nothing) freezes the moment the cutscene starts, `master` earliest, `new` at ~20 s, `old` a few seconds further (it stalls silently: its `EAGAIN` path returns without advancing the read offset). Conclusion: the title hard-syncs the cutscene to one XMA stream's PCM progress, and freezes wherever that stream stops advancing.
4. **Root cause, ffmpeg layer**: the cutscene stream contains frames that fail wmaprodec's `num_vec_coeffs > s->subframe_len` validation (160/164 vs. 128). `xmaframes_decode_packet()` ignores `decode_frame()`'s failure (`packet_loss` set, `got_frame = 0`) and still reports the packet as cleanly consumed, so the failure surfaces to xenia as `EAGAIN` — indistinguishable from codec warmup. Fixed in has207/FFmpeg#1 by returning `AVERROR_INVALIDDATA` for that case.
5. **Root cause, xenia layer** (this PR): on a decode failure `XmaContextNew::Decode()` produced no output at all for the frame, so the output ring stopped advancing and the title waited forever.

## Changes

- `XmaContextNew::DecodePacket()` now distinguishes hard decode errors from `EAGAIN` warmup (returns `int` instead of `bool`).
- On a hard decode error, emit one frame of silence (`raw_frame_` is already zero-filled) so the output ring keeps advancing, and `avcodec_flush_buffers()` the codec so a corrupt frame cannot poison subsequent valid frames.
- Rate-limit the per-frame decode error log lines (first 8 of a streak, then 1 per 512), tracked via `consecutive_decode_errors_` and reset on success and in `ClearLocked()`.
- Deduplicate identical consecutive ffmpeg `av_log` messages in `av_log_callback` (first few, then 1 per 512) — the previous unbounded flood produced thousands of identical lines per second while a stream carried undecodable frames.

## Dependency

Requires has207/FFmpeg#1 (`xmaframes-error-propagation`) plus a `third_party/FFmpeg` submodule bump after it merges; the bump is intentionally not part of this PR. Without it the fallback never engages, because the decode failure is masked as `EAGAIN`. The PR pair was validated together from a CI build of this branch with the submodule pointed at the fixed FFmpeg.

## Testing

- Before: freeze at ~20 s into the LEGO LOTR intro cutscene, 100% reproducible, log flooded with `num_vec_coeffs` errors, cutscene unskippable, game unplayable past "New Game".
- After: cutscene plays through; the corrupt stretch is heard as ~0.5 s of silence/noise; gameplay reached and playable. Log shows a handful of rate-limited decode-error lines instead of an unbounded flood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
