### PR TITLE
[CPU/A64] Revert the LDR + REV byte-swap detection in MMIO decode

### DIFF
--- a/src/xenia/cpu/mmio_handler.cc
+++ b/src/xenia/cpu/mmio_handler.cc
@@ -264,8 +264,6 @@ bool MMIOHandler::TryDecodeLoadStore(const uint8_t* p,
 #elif XE_ARCH_ARM64
   decoded_out.length = sizeof(uint32_t);
   uint32_t instruction = *reinterpret_cast<const uint32_t*>(p);
-  constexpr uint32_t kArm64RevWMask = UINT32_C(0xFFFFFC00);
-  constexpr uint32_t kArm64RevWFixed = UINT32_C(0x5AC00800);
 
   // Literal loading (PC-relative) is not handled.
 
@@ -309,21 +307,6 @@ bool MMIOHandler::TryDecodeLoadStore(const uint8_t* p,
     // Zero constant rather than a register read.
     decoded_out.is_constant = true;
     decoded_out.constant = 0;
-  }
-  if (decoded_out.is_load &&
-      decoded_out.value_reg >= DecodedLoadStore::kArm64ValueRegX0 &&
-      decoded_out.value_reg <= (DecodedLoadStore::kArm64ValueRegX0 + 30)) {
-    // Detect LDR + REV Wt, Wt so the handler doesn't byte-swap (REV will run).
-    uint32_t next_instruction =
-        *reinterpret_cast<const uint32_t*>(p + sizeof(uint32_t));
-    uint8_t rev_rd = next_instruction & 31;
-    uint8_t rev_rn = (next_instruction >> 5) & 31;
-    uint8_t value_reg =
-        decoded_out.value_reg - DecodedLoadStore::kArm64ValueRegX0;
-    if ((next_instruction & kArm64RevWMask) == kArm64RevWFixed &&
-        rev_rd == value_reg && rev_rn == value_reg) {
-      decoded_out.byte_swap = true;
-    }
   }
 
   decoded_out.mem_has_base = true;


### PR DESCRIPTION
This reverts commit adeacfa0ed13099501e373df9d8be46dc4a3f1c8
("[CPU/A64] Mirror x64 MOVBE handling for LDR + REV in MMIO decode").

The x64 special case exists because MOVBE loads and byte-swaps in one
instruction, and the handler skips that whole instruction, so it has to
do the swap itself: that is what byte_swap requests. The arm64
equivalent is two instructions, LDR followed by REV. The handler
resumes at the faulting pc plus the decoded length, which covers the
LDR alone, so the REV still executes afterwards. Setting byte_swap for
the pair made the handler swap the value too; the REV then swapped it
back, and a register that reads 0x11223344 reached the guest as
0x44332211.

This affected every 32-bit MMIO load that took the access-violation
path, that is, until the function was recompiled with accessed_mmio
set and the load started calling the handler directly.

Evidence: correctness, from the handler's resume length. The PPC test
corpus (xenia-cpu-ppc-tests, 169,044 cases) passes on this branch as a
regression gate; it does not exercise the MMIO path.