### PR TITLE
[CPU] Fix mcrf: copy the CR field instead of comparing it against zero

### DIFF
--- a/src/xenia/cpu/ppc/ppc_emit_control.cc
+++ b/src/xenia/cpu/ppc/ppc_emit_control.cc
@@ -422,11 +422,12 @@ int InstrEmit_crxor(PPCHIRBuilder& f, const InstrData& i) {
 }
 
 int InstrEmit_mcrf(PPCHIRBuilder& f, const InstrData& i) {
-  uint32_t crfd = i.XL.BO >> 2;
-  Value* bi = f.LoadCR(i.XL.BI >> 2);
-
-  f.StoreCR(crfd, bi);
-  f.UpdateCR(crfd, bi);
+  // CR[4*BF:4*BF+3] <- CR[4*BFA:4*BFA+3]
+  const uint32_t crfd = i.XL.BO >> 2;
+  const uint32_t crfs = i.XL.BI >> 2;
+  for (uint32_t bit = 0; bit < 4; ++bit) {
+    f.StoreCRField(crfd, bit, f.LoadCRField(crfs, bit));
+  }
   return 0;
 }
 

--- a/src/xenia/cpu/ppc/testing/instr_mcrf.s
+++ b/src/xenia/cpu/ppc/testing/instr_mcrf.s
@@ -51,7 +51,7 @@ test_mcrf_3:
   blr
   #_ REGISTER_OUT r3 5
   #_ REGISTER_OUT r4 5
-  #_ REGISTER_OUT r12 0x40020000
+  #_ REGISTER_OUT r12 0x20020000
 
 test_mcrf_3_constant:
   li r3, 5
@@ -62,7 +62,7 @@ test_mcrf_3_constant:
   blr
   #_ REGISTER_OUT r3 5
   #_ REGISTER_OUT r4 5
-  #_ REGISTER_OUT r12 0x40020000
+  #_ REGISTER_OUT r12 0x20020000
 
 test_mcrf_4:
   #_ REGISTER_IN r3 100
@@ -100,7 +100,7 @@ test_mcrf_5:
   #_ REGISTER_OUT r4 20
   #_ REGISTER_OUT r5 30
   #_ REGISTER_OUT r6 30
-  #_ REGISTER_OUT r12 0x00802040
+  #_ REGISTER_OUT r12 0x00802080
 
 test_mcrf_5_constant:
   li r3, 10
@@ -116,4 +116,4 @@ test_mcrf_5_constant:
   #_ REGISTER_OUT r4 20
   #_ REGISTER_OUT r5 30
   #_ REGISTER_OUT r6 30
-  #_ REGISTER_OUT r12 0x00802040
+  #_ REGISTER_OUT r12 0x00802080


### PR DESCRIPTION
mcrf BF,BFA is a four-bit field copy, SO included. The emitter lowered
it as LoadCR(BFA) -> StoreCR(BF) -> UpdateCR(BF). LoadCR and StoreCR
place the field at the source and destination bit positions, so the
store produced zeros whenever BF != BFA, and UpdateCR then rewrote
lt/gt/eq from a signed compare of that word against zero and dropped
so. A copied eq came out as gt and so was always lost; the result only
matched when the source pattern happened to compare the same way.

Lower it as four LoadCRField/StoreCRField bit copies, the way crand,
cror and the other CR logical ops already do.

Two fixtures in instr_mcrf.s encoded the old lowering rather than the
ISA; their expectations are re-derived from the definition:
  mcrf_3 / mcrf_3_constant  r12 0x40020000 -> 0x20020000 (cr0 = eq)
  mcrf_5 / mcrf_5_constant  r12 0x00802040 -> 0x00802080 (cr6 = lt)

Evidence: correctness, from the ISA definition of mcrf. The
xenia-cpu-ppc-tests corpus (169,044/169,044, the ten mcrf cases
included) runs instr_mcrf.s with the updated expectations as the gate
for this change.