### PR TITLE
[A64] Mark the host-to-guest thunk explicitly for unwind info

### DIFF
--- a/src/xenia/cpu/backend/a64/a64_backend.cc
+++ b/src/xenia/cpu/backend/a64/a64_backend.cc
@@ -205,6 +205,7 @@ HostToGuestThunk A64HelperEmitter::EmitHostToGuestThunk() {
   func_info.prolog_stack_alloc_offset =
       code_offsets.prolog_stack_alloc - code_offsets.prolog;
   func_info.stack_size = thunk_stack;
+  func_info.is_host_to_guest_thunk = true;
   func_info.lr_save_offset = 0x058;  // stp x29, x30, [sp, #0x50]
 
   void* fn = Emplace(func_info);

--- a/src/xenia/cpu/backend/a64/a64_code_cache_posix.cc
+++ b/src/xenia/cpu/backend/a64/a64_code_cache_posix.cc
@@ -301,8 +301,8 @@ void PosixA64CodeCache::InitializeUnwindEntry(
     *p++ = kDW_CFA_def_cfa_offset;
     p += WriteULEB128(p, func_info.stack_size);
 
-    if (func_info.stack_size == StackLayout::THUNK_STACK_SIZE) {
-      // Thunk: encode all callee-saved register save locations.
+    if (func_info.is_host_to_guest_thunk) {
+      // HostToGuest thunk: encode all callee-saved register save locations.
       // See a64_stack_layout.h for the layout.
       size_t cfa = func_info.stack_size;  // 224
 

--- a/src/xenia/cpu/backend/a64/a64_code_cache_win.cc
+++ b/src/xenia/cpu/backend/a64/a64_code_cache_win.cc
@@ -371,17 +371,8 @@ void Win32A64CodeCache::InitializeUnwindEntry(
   uint8_t codes[32];
   size_t codes_length;
 
-  // Guest function prologs are exactly 4 instructions (16 bytes):
-  //   sub sp, sp, #N; str x30, [sp, #64]; str x0, [sp, #48]; str xzr, [sp, #56]
-  // The HostToGuest thunk has a much larger prolog that saves all
-  // callee-saved registers. We detect it by stack size.
-  // Other thunks (GuestToHost, ResolveFunction) have different layouts
-  // but are only called from within JIT'd code; stack-alloc-only unwind
-  // info is sufficient for them since the unwinder will walk up to the
-  // HostToGuest frame which has full unwind info.
-  bool is_host_to_guest_thunk =
-      (func_info.stack_size == StackLayout::THUNK_STACK_SIZE &&
-       func_info.code_size.prolog > 16);
+  // Marked by the emitter: frame and prolog size cannot tell the thunk apart.
+  bool is_host_to_guest_thunk = func_info.is_host_to_guest_thunk;
 
   if (is_host_to_guest_thunk) {
     codes_length = BuildThunkUnwindCodes(codes);

--- a/src/xenia/cpu/backend/code_cache_base.h
+++ b/src/xenia/cpu/backend/code_cache_base.h
@@ -51,6 +51,8 @@ struct EmitFunctionInfo {
   } code_size;
   size_t prolog_stack_alloc_offset;
   size_t stack_size;
+  // Set only by EmitHostToGuestThunk; a guest frame can look identical.
+  bool is_host_to_guest_thunk;
 #if XE_ARCH_ARM64
   // Offset from SP where x30 (LR) is saved.  ARM64 callees save LR
   // explicitly at varying offsets; the unwind info generator needs this


### PR DESCRIPTION
EmitFunctionInfo gains is_host_to_guest_thunk, set only by
EmitHostToGuestThunk. Both code caches select the full callee-saved
unwind description from that flag instead of inferring it: the POSIX
cache compared stack_size against THUNK_STACK_SIZE, the Windows cache
additionally required a prolog longer than 16 bytes.

Neither inference holds. A guest function with 144 bytes of locals has
the same 224-byte frame as the thunk, and its frame holds locals at the
offsets the thunk's record claims for saved registers, so an unwind
through such a function would restore x19-x28 and q8-q15 from guest
locals. The guest prolog also runs PushStackpoint, so it is no longer
the four instructions the Windows heuristic assumed.

Behaviour change: only unwind metadata; no emitted guest code changes.
The guest-to-host and resolve thunks keep stack-alloc-only unwind
info, as before, since the unwinder walks up to the host-to-guest
frame.

Evidence: PPC corpus gate 169,044/169,044 passing; the unwind path
itself has no runtime measurement.