### PR TITLE
[CPU] Make breakpoints and guest traps reachable on POSIX hosts

### DIFF
--- a/src/xenia/base/debugging_mac.cc
+++ b/src/xenia/base/debugging_mac.cc
@@ -27,7 +27,12 @@ bool IsDebuggerAttached() {
   return (info.kp_proc.p_flag & P_TRACED) != 0;
 }
 
-void Break() { __builtin_debugtrap(); }
+void Break() {
+  if (!IsDebuggerAttached()) {
+    return;
+  }
+  __builtin_debugtrap();
+}
 
 namespace internal {
 void DebugPrint(const char* s) { std::clog << s << std::endl; }

--- a/src/xenia/base/debugging_posix.cc
+++ b/src/xenia/base/debugging_posix.cc
@@ -13,7 +13,6 @@
 #include <cstdarg>
 #include <fstream>
 #include <iostream>
-#include <mutex>
 #include <sstream>
 
 #include "xenia/base/string_buffer.h"
@@ -41,15 +40,14 @@ bool IsDebuggerAttached() {
 }
 
 void Break() {
-  static std::once_flag flag;
-  std::call_once(flag, []() {
-    // Install handler for sigtrap only once
-    std::signal(SIGTRAP, [](int) {
-      // Forward signal to default handler after being caught
-      std::signal(SIGTRAP, SIG_DFL);
-    });
-  });
+  if (!IsDebuggerAttached()) {
+    return;
+  }
+#if defined(__clang__)
+  __builtin_debugtrap();
+#else
   std::raise(SIGTRAP);
+#endif
 }
 
 namespace internal {

--- a/src/xenia/base/exception_handler.cc
+++ b/src/xenia/base/exception_handler.cc
@@ -41,6 +41,8 @@ namespace xe {
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 bool IsArm64LoadPrefetchStore(uint32_t instruction, bool& is_store_out) {
   if ((instruction & kArm64LoadLiteralFMask) == kArm64LoadLiteralFixed) {
+    // LDR/LDRSW/PRFM (literal) only read.
+    is_store_out = false;
     return true;
   }
   if ((instruction & kArm64SystemSysFMask) == kArm64SystemSysFixed) {

--- a/src/xenia/base/exception_handler_posix.cc
+++ b/src/xenia/base/exception_handler_posix.cc
@@ -28,6 +28,7 @@ bool signal_handlers_installed_ = false;
 struct sigaction original_sigill_handler_;
 struct sigaction original_sigsegv_handler_;
 struct sigaction original_sigbus_handler_;
+struct sigaction original_sigtrap_handler_;
 
 // This can be as large as needed, but isn't often needed.
 // As we will be sometimes firing many exceptions we want to avoid having to
@@ -169,6 +170,16 @@ static void ExceptionHandlerCallback(int signal_number, siginfo_t* signal_info,
 
   Exception ex;
   switch (signal_number) {
+    case SIGTRAP:
+#if XE_ARCH_AMD64
+      // int3 reports the byte after it; Exception::pc() is the trap itself.
+      if (signal_info->si_code > 0 &&
+          *reinterpret_cast<const uint8_t*>(uintptr_t(thread_context.rip) -
+                                            1) == 0xCC) {
+        thread_context.rip -= 1;
+      }
+#endif  // XE_ARCH_AMD64
+      [[fallthrough]];
     case SIGILL:
       ex.InitializeIllegalInstruction(&thread_context);
       break;
@@ -396,14 +407,19 @@ static void ExceptionHandlerCallback(int signal_number, siginfo_t* signal_info,
           std::memcpy(&mcontext_fpsimd->vregs[modified_register_index],
                       &thread_context.v[modified_register_index],
                       sizeof(vec128_t));
-          mcontext.regs[modified_register_index] =
-              thread_context.x[modified_register_index];
         }
       }
 #endif  // XE_PLATFORM_MAC
 #endif  // XE_ARCH
       return;
     }
+  }
+
+  if (signal_number == SIGTRAP) {
+    // Returning would resume past the trap; hand it to the original handler.
+    sigaction(SIGTRAP, &original_sigtrap_handler_, nullptr);
+    raise(SIGTRAP);
+    return;
   }
 
   // Unhandled: restore the original disposition so the kernel re-delivers
@@ -449,6 +465,9 @@ void ExceptionHandler::Install(Handler fn, void* data) {
     if (sigaction(SIGBUS, &signal_handler, &original_sigbus_handler_) != 0) {
       assert_always("Failed to install new SIGBUS handler");
     }
+    if (sigaction(SIGTRAP, &signal_handler, &original_sigtrap_handler_) != 0) {
+      assert_always("Failed to install new SIGTRAP handler");
+    }
     signal_handlers_installed_ = true;
   }
 
@@ -491,6 +510,9 @@ void ExceptionHandler::Uninstall(Handler fn, void* data) {
       }
       if (sigaction(SIGBUS, &original_sigbus_handler_, NULL) != 0) {
         assert_always("Failed to restore original SIGBUS handler");
+      }
+      if (sigaction(SIGTRAP, &original_sigtrap_handler_, NULL) != 0) {
+        assert_always("Failed to restore original SIGTRAP handler");
       }
       signal_handlers_installed_ = false;
     }

--- a/src/xenia/cpu/backend/a64/a64_backend.cc
+++ b/src/xenia/cpu/backend/a64/a64_backend.cc
@@ -41,6 +41,7 @@
 #include "xenia/cpu/ppc/ppc_context.h"
 #include "xenia/cpu/processor.h"
 #include "xenia/cpu/stack_walker.h"
+#include "xenia/cpu/thread_debug_info.h"
 #include "xenia/cpu/thread_state.h"
 #include "xenia/cpu/xex_module.h"
 
@@ -1129,21 +1130,118 @@ std::unique_ptr<GuestFunction> A64Backend::CreateGuestFunction(
   return std::make_unique<A64Function>(module, address);
 }
 
+namespace {
+
+// Encoding 31 reads as XZR in every branch form below.
+uint64_t ReadXReg(const HostThreadContext& ctx, uint32_t n) {
+  return n == 31 ? 0 : ctx.x[n];
+}
+
+bool TestCondition(uint64_t pstate, uint32_t cond) {
+  const bool n = (pstate >> 31) & 1;
+  const bool z = (pstate >> 30) & 1;
+  const bool c = (pstate >> 29) & 1;
+  const bool v = (pstate >> 28) & 1;
+  bool result;
+  switch (cond >> 1) {
+    case 0b000:
+      result = z;
+      break;
+    case 0b001:
+      result = c;
+      break;
+    case 0b010:
+      result = n;
+      break;
+    case 0b011:
+      result = v;
+      break;
+    case 0b100:
+      result = c && !z;
+      break;
+    case 0b101:
+      result = n == v;
+      break;
+    case 0b110:
+      result = (n == v) && !z;
+      break;
+    default:
+      result = true;
+      break;
+  }
+  if ((cond & 1) && cond != 0b1111) {
+    result = !result;
+  }
+  return result;
+}
+
+int64_t SignExtend(uint64_t value, uint32_t bits) {
+  const uint32_t shift = 64 - bits;
+  return int64_t(value << shift) >> shift;
+}
+
+}  // namespace
+
 uint64_t A64Backend::CalculateNextHostInstruction(ThreadDebugInfo* thread_info,
                                                   uint64_t current_pc) {
-  // ARM64 instructions are fixed 4 bytes.
-  return current_pc + 4;
+  const auto& ctx = thread_info->host_context;
+  const uint32_t insn = xe::load<uint32_t>(reinterpret_cast<void*>(current_pc));
+  const uint64_t next_pc = current_pc + 4;
+
+  // B  imm26  0b000101...    BL imm26  0b100101...
+  if ((insn & 0x7C000000) == 0x14000000) {
+    return current_pc + SignExtend(insn & 0x03FFFFFF, 26) * 4;
+  }
+  // B.cond / BC.cond imm19   0b01010100 imm19 x cond
+  if ((insn & 0xFF000000) == 0x54000000) {
+    if (!TestCondition(ctx.pstate, insn & 0xF)) {
+      return next_pc;
+    }
+    return current_pc + SignExtend((insn >> 5) & 0x7FFFF, 19) * 4;
+  }
+  // CBZ / CBNZ  sf 011010 op imm19 Rt
+  if ((insn & 0x7E000000) == 0x34000000) {
+    uint64_t value = ReadXReg(ctx, insn & 0x1F);
+    if (!(insn & 0x80000000)) {
+      value = uint32_t(value);
+    }
+    const bool nonzero = value != 0;
+    const bool is_cbnz = (insn >> 24) & 1;
+    if (nonzero != is_cbnz) {
+      return next_pc;
+    }
+    return current_pc + SignExtend((insn >> 5) & 0x7FFFF, 19) * 4;
+  }
+  // TBZ / TBNZ  b5 011011 op b40 imm14 Rt
+  if ((insn & 0x7E000000) == 0x36000000) {
+    const uint32_t bit = ((insn >> 26) & 0x20) | ((insn >> 19) & 0x1F);
+    const bool set = (ReadXReg(ctx, insn & 0x1F) >> bit) & 1;
+    const bool is_tbnz = (insn >> 24) & 1;
+    if (set != is_tbnz) {
+      return next_pc;
+    }
+    return current_pc + SignExtend((insn >> 5) & 0x3FFF, 14) * 4;
+  }
+  // BR / BLR / RET  Rn
+  if ((insn & 0xFFFFFC1F) == 0xD61F0000 || (insn & 0xFFFFFC1F) == 0xD63F0000 ||
+      (insn & 0xFFFFFC1F) == 0xD65F0000) {
+    return ReadXReg(ctx, (insn >> 5) & 0x1F);
+  }
+  return next_pc;
 }
 
 // ARM64 BRK #0 encoding (4 bytes, fixed-width instruction).
 static constexpr uint32_t kArm64Brk0 = 0xD4200000;
 
 void A64Backend::InstallBreakpoint(Breakpoint* breakpoint) {
-  breakpoint->ForEachHostAddress([breakpoint](uint64_t host_address) {
+  breakpoint->ForEachHostAddress([this, breakpoint](uint64_t host_address) {
     auto ptr = reinterpret_cast<void*>(host_address);
     auto original_bytes = xe::load<uint32_t>(ptr);
     assert_true(original_bytes != kArm64Brk0);
-    xe::store<uint32_t>(ptr, kArm64Brk0);
+    if (!code_cache()->PatchCode(ptr, &kArm64Brk0, sizeof(kArm64Brk0))) {
+      assert_always();
+      return;
+    }
     breakpoint->backend_data().emplace_back(host_address, original_bytes);
   });
 }
@@ -1162,7 +1260,10 @@ void A64Backend::InstallBreakpoint(Breakpoint* breakpoint, Function* fn) {
   auto ptr = reinterpret_cast<void*>(host_address);
   auto original_bytes = xe::load<uint32_t>(ptr);
   assert_true(original_bytes != kArm64Brk0);
-  xe::store<uint32_t>(ptr, kArm64Brk0);
+  if (!code_cache()->PatchCode(ptr, &kArm64Brk0, sizeof(kArm64Brk0))) {
+    assert_always();
+    return;
+  }
   breakpoint->backend_data().emplace_back(host_address, original_bytes);
 }
 
@@ -1171,7 +1272,8 @@ void A64Backend::UninstallBreakpoint(Breakpoint* breakpoint) {
     auto ptr = reinterpret_cast<uint8_t*>(pair.first);
     auto instruction_bytes = xe::load<uint32_t>(ptr);
     assert_true(instruction_bytes == kArm64Brk0);
-    xe::store<uint32_t>(ptr, static_cast<uint32_t>(pair.second));
+    const uint32_t original_bytes = static_cast<uint32_t>(pair.second);
+    code_cache()->PatchCode(ptr, &original_bytes, sizeof(original_bytes));
   }
   breakpoint->backend_data().clear();
 }

--- a/src/xenia/cpu/backend/a64/a64_emitter.cc
+++ b/src/xenia/cpu/backend/a64/a64_emitter.cc
@@ -10,6 +10,7 @@
 #include "xenia/cpu/backend/a64/a64_emitter.h"
 
 #include <cstring>
+#include <string>
 
 #include "xenia/base/debugging.h"
 #include "xenia/base/logging.h"
@@ -26,6 +27,7 @@
 #include "xenia/cpu/hir/label.h"
 #include "xenia/cpu/ppc/ppc_context.h"
 #include "xenia/cpu/processor.h"
+#include "xenia/cpu/thread_state.h"
 
 DECLARE_int64(a64_max_stackpoints);
 DECLARE_bool(a64_enable_host_guest_stack_synchronization);
@@ -442,7 +444,33 @@ void A64Emitter::RecordSequenceSample(const hir::Instr* i, uint32_t backend_key,
 
 void A64Emitter::DebugBreak() { brk(0xF000); }
 
-void A64Emitter::Trap(uint16_t trap_type) { brk(trap_type); }
+static uint64_t TrapDebugBreak(void*) {
+  XELOGE("tw/td forced trap hit! This should be a crash!");
+  if (cvars::break_on_debugbreak) {
+    xe::debugging::Break();
+  }
+  return 0;
+}
+
+void A64Emitter::Trap(uint16_t trap_type) {
+  switch (trap_type) {
+    case 20:
+    case 26:
+      CallNative(reinterpret_cast<void*>(&backend::TrapDebugPrint));
+      break;
+    case 0:
+    case 22:
+      CallNative(reinterpret_cast<void*>(&TrapDebugBreak));
+      break;
+    case 25:
+      break;
+    default:
+      XELOGW("Unknown trap type {}", trap_type);
+      // Not brk #0: that is the breakpoint encoding.
+      brk(0xF002);
+      break;
+  }
+}
 
 void A64Emitter::b(const Xbyak_aarch64::Cond cond,
                    const Xbyak_aarch64::Label& label) {

--- a/src/xenia/cpu/backend/backend.cc
+++ b/src/xenia/cpu/backend/backend.cc
@@ -10,9 +10,17 @@
 #include "xenia/cpu/backend/backend.h"
 
 #include <cstring>
+#include <string>
 
 #include "xenia/base/byte_order.h"
+#include "xenia/base/cvar.h"
+#include "xenia/base/debugging.h"
+#include "xenia/base/logging.h"
 #include "xenia/cpu/ppc/ppc_context.h"
+#include "xenia/cpu/thread_state.h"
+
+DEFINE_bool(debugprint_trap_log, false,
+            "Log debugprint traps to the active debugger", "CPU");
 
 namespace xe {
 namespace cpu {
@@ -31,6 +39,20 @@ void* Backend::AllocThreadData() { return nullptr; }
 void Backend::FreeThreadData(void* thread_data) {}
 
 void (*preempt_yield_handler)(void* raw_context) = nullptr;
+
+uint64_t TrapDebugPrint(void* raw_context) {
+  auto thread_state =
+      reinterpret_cast<ppc::PPCContext_s*>(raw_context)->thread_state;
+  uint32_t str_ptr = uint32_t(thread_state->context()->r[3]);
+  uint32_t str_length = uint32_t(thread_state->context()->r[4]);
+  auto str = thread_state->memory()->TranslateVirtual<const char*>(str_ptr);
+  std::string message(str, str_length);
+  XELOGD("(DebugPrint) {}", message);
+  if (cvars::debugprint_trap_log) {
+    debugging::DebugPrint("(DebugPrint) {}", message);
+  }
+  return 0;
+}
 
 uint32_t Backend::ReservedLoad32(ppc::PPCContext* context, uint32_t address) {
   return xe::byte_swap(*context->TranslateVirtual<uint32_t*>(address));

--- a/src/xenia/cpu/backend/backend.h
+++ b/src/xenia/cpu/backend/backend.h
@@ -201,6 +201,8 @@ struct GuestTrampolineGroup
   }
 };
 
+uint64_t TrapDebugPrint(void* raw_context);
+
 // Registered by the cooperative scheduler when it starts, null otherwise. A
 // JIT safepoint calls it with the PPCContext once the scheduler has raised the
 // context's preempt_requested flag.

--- a/src/xenia/cpu/backend/code_cache.h
+++ b/src/xenia/cpu/backend/code_cache.h
@@ -35,6 +35,10 @@ class CodeCache {
 
   // Finds platform-specific function unwind info for the given host PC.
   virtual void* LookupUnwindInfo(uint64_t host_pc) = 0;
+
+  // Writes through the write view and invalidates the instruction cache.
+  virtual bool PatchCode(void* execute_address, const void* data,
+                         size_t size) = 0;
 };
 
 }  // namespace backend

--- a/src/xenia/cpu/backend/code_cache_base.h
+++ b/src/xenia/cpu/backend/code_cache_base.h
@@ -10,6 +10,7 @@
 #ifndef XENIA_CPU_BACKEND_CODE_CACHE_BASE_H_
 #define XENIA_CPU_BACKEND_CODE_CACHE_BASE_H_
 
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -124,6 +125,33 @@ class CodeCacheBase : public CodeCache {
                : kGeneratedCodeExecuteBase;
   }
   size_t total_size() const override { return kGeneratedCodeSize; }
+
+  bool PatchCode(void* execute_address, const void* data,
+                 size_t size) override {
+    auto* addr = reinterpret_cast<uint8_t*>(execute_address);
+    if (!generated_code_execute_base_ || !generated_code_write_base_ ||
+        addr < generated_code_execute_base_ || size > kGeneratedCodeSize ||
+        addr > generated_code_execute_base_ + (kGeneratedCodeSize - size)) {
+      return false;
+    }
+    uint8_t* write_address =
+        generated_code_write_base_ + (addr - generated_code_execute_base_);
+#if XE_PLATFORM_MAC && XE_ARCH_ARM64
+    const bool jit_write_toggle =
+        generated_code_execute_base_ == generated_code_write_base_;
+    if (jit_write_toggle) {
+      pthread_jit_write_protect_np(0);
+    }
+#endif
+    std::copy_n(static_cast<const uint8_t*>(data), size, write_address);
+#if XE_PLATFORM_MAC && XE_ARCH_ARM64
+    if (jit_write_toggle) {
+      pthread_jit_write_protect_np(1);
+    }
+#endif
+    self().FlushCodeRange(write_address, size);
+    return true;
+  }
 
   bool has_indirection_table() { return indirection_table_base_ != nullptr; }
 

--- a/src/xenia/cpu/backend/x64/x64_backend.cc
+++ b/src/xenia/cpu/backend/x64/x64_backend.cc
@@ -548,12 +548,17 @@ uint64_t X64Backend::CalculateNextHostInstruction(ThreadDebugInfo* thread_info,
   }
 }
 
+static constexpr uint8_t kUd2[2] = {0x0F, 0x0B};
+
 void X64Backend::InstallBreakpoint(Breakpoint* breakpoint) {
-  breakpoint->ForEachHostAddress([breakpoint](uint64_t host_address) {
+  breakpoint->ForEachHostAddress([this, breakpoint](uint64_t host_address) {
     auto ptr = reinterpret_cast<void*>(host_address);
     auto original_bytes = xe::load_and_swap<uint16_t>(ptr);
     assert_true(original_bytes != 0x0F0B);
-    xe::store_and_swap<uint16_t>(ptr, 0x0F0B);
+    if (!code_cache()->PatchCode(ptr, kUd2, sizeof(kUd2))) {
+      assert_always();
+      return;
+    }
     breakpoint->backend_data().emplace_back(host_address, original_bytes);
   });
 }
@@ -573,7 +578,10 @@ void X64Backend::InstallBreakpoint(Breakpoint* breakpoint, Function* fn) {
   auto ptr = reinterpret_cast<void*>(host_address);
   auto original_bytes = xe::load_and_swap<uint16_t>(ptr);
   assert_true(original_bytes != 0x0F0B);
-  xe::store_and_swap<uint16_t>(ptr, 0x0F0B);
+  if (!code_cache()->PatchCode(ptr, kUd2, sizeof(kUd2))) {
+    assert_always();
+    return;
+  }
   breakpoint->backend_data().emplace_back(host_address, original_bytes);
 }
 
@@ -582,7 +590,10 @@ void X64Backend::UninstallBreakpoint(Breakpoint* breakpoint) {
     auto ptr = reinterpret_cast<uint8_t*>(pair.first);
     auto instruction_bytes = xe::load_and_swap<uint16_t>(ptr);
     assert_true(instruction_bytes == 0x0F0B);
-    xe::store_and_swap<uint16_t>(ptr, static_cast<uint16_t>(pair.second));
+    // backend_data holds the byte-swapped load, so swap back to memory order.
+    const uint16_t original_bytes =
+        xe::byte_swap(static_cast<uint16_t>(pair.second));
+    code_cache()->PatchCode(ptr, &original_bytes, sizeof(original_bytes));
   }
   breakpoint->backend_data().clear();
 }

--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -40,8 +40,6 @@
 #include "xenia/cpu/symbol.h"
 #include "xenia/cpu/thread_state.h"
 
-DEFINE_bool(debugprint_trap_log, false,
-            "Log debugprint traps to the active debugger", "CPU");
 DEFINE_bool(ignore_undefined_externs, true,
             "Don't exit when an undefined extern is called.", "CPU");
 DEFINE_bool(emit_source_annotations, false,
@@ -435,26 +433,7 @@ void X64Emitter::DebugBreak() {
 }
 
 uint64_t TrapDebugPrint(void* raw_context, uint64_t address) {
-  auto thread_state =
-      reinterpret_cast<ppc::PPCContext_s*>(raw_context)->thread_state;
-  uint32_t str_ptr = uint32_t(thread_state->context()->r[3]);
-  uint32_t str_length = uint32_t(thread_state->context()->r[4]);
-
-  auto str = thread_state->memory()->TranslateVirtual<const char*>(str_ptr);
-
-  // Allocate temporary buffer and null-terminate to respect length parameter
-  char* string_tmp = new char[str_length + 1];
-  std::memcpy(string_tmp, str, str_length);
-  string_tmp[str_length] = 0;
-
-  XELOGD("(DebugPrint) {}", string_tmp);
-
-  if (cvars::debugprint_trap_log) {
-    debugging::DebugPrint("(DebugPrint) {}", string_tmp);
-  }
-
-  delete[] string_tmp;
-  return 0;
+  return backend::TrapDebugPrint(raw_context);
 }
 
 uint64_t TrapDebugBreak(void* raw_context, uint64_t address) {


### PR DESCRIPTION
ExceptionHandler never installed a SIGTRAP handler on POSIX, so the
BRK (arm64) and int3 (x86-64) that InstallBreakpoint, DebugBreak and
OPCODE_TRAP emit hit the default disposition and killed the process.
The breakpoint and trap paths were dead on Linux and macOS.

SIGTRAP handler. Install/Uninstall now own SIGTRAP alongside SIGILL,
SIGSEGV and SIGBUS. A trap is presented to the backends as an illegal
instruction exception, and they re-check the encoding before claiming
it. On x86-64 the saved RIP is the byte after int3, so for kernel-raised
traps (si_code > 0) the pc is backed up over the 0xCC byte to match
Exception::pc(). An unclaimed SIGTRAP is not retried like a fault:
returning would resume past the instruction, so the original
disposition is restored and the signal re-raised.

A64Emitter::Trap dispatches by trap type as X64Emitter::Trap does: 20/26
call backend::TrapDebugPrint, the debug-print handler both backends now
share (it moves out of x64_emitter.cc together with
--debugprint_trap_log, so the a64 trap honours that flag too), 0/22 call
TrapDebugBreak, 25 is a no-op, and anything else emits brk #0xF002. A
bare brk #0 for type 0 was indistinguishable from the breakpoint
encoding.

Breakpoint patching goes through a new CodeCache::PatchCode, a pure
virtual on CodeCache implemented once in CodeCacheBase: it writes via
the write view, toggles the macOS MAP_JIT write gate when the views
alias, and flushes the patched range. Storing through the execute view
does not work where it is a separate read-only mapping. x64 patches the
same way.

A64Backend::CalculateNextHostInstruction follows B, BL, B.cond, CBZ,
CBNZ, TBZ, TBNZ, BR, BLR and RET from the captured context instead of
returning pc + 4, so single-step lands where execution goes.

Two Linux arm64 handler fixes: IsArm64LoadPrefetchStore left
is_store_out unset for literal loads, so callers classified them from
an uninitialised value; the vector-register write-back also wrote
regs[v], clobbering the general register of the same index.

Behaviour changes to note:
- debugging::Break() on Linux no longer installs its own SIGTRAP
  disposition (which displaced the exception handler and then left
  SIG_DFL behind), and is a no-op unless a debugger is attached; before,
  the first call continued and later calls killed the process. The same
  guard is added on macOS, so trap types 0/22 with break_on_debugbreak
  no longer kill an undebugged process there.
- CodeCache::PatchCode is a new pure virtual; every implementation in
  the tree derives from CodeCacheBase, which provides it.

Evidence: correctness. The x86-64 backend and the Linux arm64 handler
hunks are not compiled on the macOS arm64 host this was written on and
need a Linux x86-64 and a Windows build to confirm. The PPC test corpus
(xenia-cpu-ppc-tests) is unaffected and serves only as a regression
gate.