### PR TITLE
[Base/POSIX] Fix memory, file, clock and process helpers

### DIFF
--- a/src/xenia/base/clock_posix.cc
+++ b/src/xenia/base/clock_posix.cc
@@ -63,9 +63,21 @@ uint64_t Clock::QueryHostSystemTime() {
       now.tv_usec * 10);
 }
 
-uint64_t Clock::QueryHostUptimeMillis() {
-  return host_tick_count_platform() * 1000 / host_tick_frequency_platform();
+// ticks * 10000000 overflows uint64 after ~213 days of nanosecond ticks.
+static uint64_t TicksTo(uint64_t ticks, uint64_t units) {
+  static const uint64_t freq = Clock::host_tick_frequency_platform();
+  if (!freq) {
+    return 0;
+  }
+  return (ticks / freq) * units + ((ticks % freq) * units) / freq;
 }
 
-uint64_t Clock::QueryHostInterruptTime() { return host_tick_count_platform(); }
+uint64_t Clock::QueryHostUptimeMillis() {
+  return TicksTo(Clock::host_tick_count_platform(), 1000);
+}
+
+uint64_t Clock::QueryHostInterruptTime() {
+  // 100 ns units, as KUSER_SHARED InterruptTime on Windows.
+  return TicksTo(Clock::host_tick_count_platform(), 10000000ull);
+}
 }  // namespace xe

--- a/src/xenia/base/filesystem_posix.cc
+++ b/src/xenia/base/filesystem_posix.cc
@@ -23,6 +23,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cstring>
 #if XE_PLATFORM_MAC
 #include <limits.h>
 #include <mach-o/dyld.h>
@@ -91,10 +92,15 @@ std::filesystem::path GetUserFolder() {
   // if HOME not set, fall back to this
   if (home == NULL) {
     struct passwd pw1;
-    struct passwd* pw;
+    struct passwd* pw = nullptr;
     char buf[4096];  // could potentionally lower this
-    getpwuid_r(getuid(), &pw1, buf, sizeof(buf), &pw);
-    assert(&pw1 == pw);  // sanity check
+    // getpwuid_r returns 0 with a null result for "no entry".
+    if (getpwuid_r(getuid(), &pw1, buf, sizeof(buf), &pw) != 0 || !pw) {
+      XELOGW(
+          "GetUserFolder: no HOME and no passwd entry; using the current "
+          "directory");
+      return std::filesystem::current_path() / ".local" / "share";
+    }
     home = pw->pw_dir;
   }
 
@@ -149,8 +155,10 @@ bool CreateEmptyFile(const std::filesystem::path& path) {
 
 class PosixFileHandle : public FileHandle {
  public:
-  PosixFileHandle(std::filesystem::path path, int handle)
-      : FileHandle(std::move(path)), handle_(handle) {}
+  PosixFileHandle(std::filesystem::path path, int handle, bool append_only)
+      : FileHandle(std::move(path)),
+        handle_(handle),
+        append_only_(append_only) {}
   ~PosixFileHandle() override {
     close(handle_);
     handle_ = -1;
@@ -168,7 +176,9 @@ class PosixFileHandle : public FileHandle {
   }
   bool Write(size_t file_offset, const void* buffer, size_t buffer_length,
              size_t* out_bytes_written) override {
-    ssize_t out = pwrite(handle_, buffer, buffer_length, file_offset);
+    ssize_t out = append_only_
+                      ? write(handle_, buffer, buffer_length)
+                      : pwrite(handle_, buffer, buffer_length, file_offset);
     if (out >= 0) {
       *out_bytes_written = out;
       return true;
@@ -184,6 +194,7 @@ class PosixFileHandle : public FileHandle {
 
  private:
   int handle_ = -1;
+  bool append_only_ = false;
 };
 
 std::unique_ptr<FileHandle> FileHandle::OpenExisting(
@@ -196,7 +207,7 @@ std::unique_ptr<FileHandle> FileHandle::OpenExisting(
                         FileAccess::kGenericExecute | FileAccess::kGenericAll);
   const bool wants_write =
       desired_access & (FileAccess::kGenericWrite | FileAccess::kFileWriteData |
-                        FileAccess::kGenericAll);
+                        FileAccess::kFileAppendData | FileAccess::kGenericAll);
   int open_access;
   if (wants_read && wants_write) {
     open_access = O_RDWR;
@@ -205,7 +216,12 @@ std::unique_ptr<FileHandle> FileHandle::OpenExisting(
   } else {
     open_access = O_RDONLY;
   }
-  if (desired_access & FileAccess::kFileAppendData) {
+  // pwrite(2) ignores the offset on an O_APPEND descriptor.
+  const bool append_only = (desired_access & FileAccess::kFileAppendData) &&
+                           !(desired_access & (FileAccess::kGenericWrite |
+                                               FileAccess::kFileWriteData |
+                                               FileAccess::kGenericAll));
+  if (append_only) {
     open_access |= O_APPEND;
   }
   int handle = open(path.c_str(), open_access);
@@ -213,7 +229,7 @@ std::unique_ptr<FileHandle> FileHandle::OpenExisting(
     // TODO(benvanik): pick correct response.
     return nullptr;
   }
-  return std::make_unique<PosixFileHandle>(path, handle);
+  return std::make_unique<PosixFileHandle>(path, handle, append_only);
 }
 
 std::optional<FileInfo> GetInfo(const std::filesystem::path& path) {
@@ -257,12 +273,17 @@ std::vector<FileInfo> ListFilesUnsorted(const std::filesystem::path& path) {
 
     info.name = ent->d_name;
     struct stat st;
-    stat((path / info.name).c_str(), &st);
+    if (stat((path / info.name).c_str(), &st) != 0) {
+      if (lstat((path / info.name).c_str(), &st) != 0) {
+        std::memset(&st, 0, sizeof(st));
+      }
+    }
     info.create_timestamp = convertUnixtimeToWinFiletime(st.st_ctime);
     info.access_timestamp = convertUnixtimeToWinFiletime(st.st_atime);
     info.write_timestamp = convertUnixtimeToWinFiletime(st.st_mtime);
     info.path = path;
-    if (ent->d_type == DT_DIR) {
+    // d_type is DT_LNK for a symlink to a directory; classify from the stat.
+    if (S_ISDIR(st.st_mode)) {
       info.type = FileInfo::Type::kDirectory;
       info.total_size = 0;
     } else {

--- a/src/xenia/base/mapped_memory_posix.cc
+++ b/src/xenia/base/mapped_memory_posix.cc
@@ -16,18 +16,23 @@
 #include <memory>
 
 #include "xenia/base/filesystem.h"
+#include "xenia/base/memory.h"
 #include "xenia/base/platform.h"
 
 namespace xe {
 
 class PosixMappedMemory : public MappedMemory {
  public:
-  PosixMappedMemory(void* data, size_t size, int file_descriptor)
-      : MappedMemory(data, size), file_descriptor_(file_descriptor) {}
+  PosixMappedMemory(void* data, size_t size, int file_descriptor,
+                    void* map_base, size_t map_length)
+      : MappedMemory(data, size),
+        file_descriptor_(file_descriptor),
+        map_base_(map_base),
+        map_length_(map_length) {}
 
   ~PosixMappedMemory() override {
-    if (data_) {
-      munmap(data_, size());
+    if (map_base_) {
+      munmap(map_base_, map_length_);
     }
     if (file_descriptor_ >= 0) {
       close(file_descriptor_);
@@ -63,20 +68,36 @@ class PosixMappedMemory : public MappedMemory {
       return nullptr;
     }
 
-    void* data =
-        mmap(0, map_length, protection, MAP_SHARED, file_descriptor, offset);
-    if (data == MAP_FAILED) {
+    // mmap past EOF faults with SIGBUS; grow the file as CreateFileMapping
+    // does.
+    if (mode == Mode::kReadWrite && offset + map_length > file_size) {
+      if (ftruncate(file_descriptor, off_t(offset + map_length))) {
+        close(file_descriptor);
+        return nullptr;
+      }
+    }
+
+    const size_t page = xe::memory::page_size();
+    const size_t aligned_offset = offset & ~(page - 1);
+    const size_t delta = offset - aligned_offset;
+    const size_t map_span = map_length + delta;
+
+    void* map_base = mmap(0, map_span, protection, MAP_SHARED, file_descriptor,
+                          off_t(aligned_offset));
+    if (map_base == MAP_FAILED) {
       close(file_descriptor);
       return nullptr;
     }
 
-    return std::make_unique<PosixMappedMemory>(data, map_length,
-                                               file_descriptor);
+    void* data = static_cast<uint8_t*>(map_base) + delta;
+    return std::make_unique<PosixMappedMemory>(
+        data, map_length, file_descriptor, map_base, map_span);
   }
 
   void Close(uint64_t truncate_size) override {
-    if (data_) {
-      munmap(data_, size());
+    if (map_base_) {
+      munmap(map_base_, map_length_);
+      map_base_ = nullptr;
       data_ = nullptr;
     }
     if (file_descriptor_ >= 0) {
@@ -88,10 +109,12 @@ class PosixMappedMemory : public MappedMemory {
     }
   }
 
-  void Flush() override { msync(data(), size(), MS_ASYNC); }
+  void Flush() override { msync(map_base_, map_length_, MS_ASYNC); }
 
  private:
   int file_descriptor_;
+  void* map_base_ = nullptr;
+  size_t map_length_ = 0;
 };
 
 std::unique_ptr<MappedMemory> MappedMemory::Open(

--- a/src/xenia/base/memory_posix.cc
+++ b/src/xenia/base/memory_posix.cc
@@ -23,6 +23,7 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 
 #if XE_PLATFORM_MAC
 #include <mach/mach.h>
@@ -90,7 +91,10 @@ void AndroidShutdown() {
 }
 #endif
 
-size_t page_size() { return getpagesize(); }
+size_t page_size() {
+  static const size_t page_size_ = static_cast<size_t>(getpagesize());
+  return page_size_;
+}
 size_t allocation_granularity() { return page_size(); }
 
 uint32_t ToPosixProtectFlags(PageAccess access) {
@@ -187,6 +191,27 @@ static void InstallCleanupHandlers() {
 }
 #endif  // !XE_PLATFORM_ANDROID
 
+// Lets a Win32-style length-0 release find the reservation's extent.
+static std::mutex g_reservations_mutex;
+static std::unordered_map<void*, size_t> g_reservations;
+
+static void RememberReservation(void* base_address, size_t length) {
+  std::lock_guard guard(g_reservations_mutex);
+  g_reservations[base_address] = length;
+}
+
+// Erase before munmap: a concurrent AllocFixed may reuse the address.
+static size_t TakeReservationLength(void* base_address) {
+  std::lock_guard guard(g_reservations_mutex);
+  auto it = g_reservations.find(base_address);
+  if (it == g_reservations.end()) {
+    return 0;
+  }
+  const size_t length = it->second;
+  g_reservations.erase(it);
+  return length;
+}
+
 void* AllocFixed(void* base_address, size_t length,
                  AllocationType allocation_type, PageAccess access) {
   // mmap does not support reserve / commit, so ignore allocation_type.
@@ -236,6 +261,7 @@ void* AllocFixed(void* base_address, size_t length,
     return nullptr;
   }
 
+  RememberReservation(result, length);
   return result;
 }
 
@@ -248,6 +274,7 @@ bool DeallocFixed(void* base_address, size_t length,
   std::lock_guard guard(g_mapped_file_ranges_mutex);
   for (const auto& mapped_range : mapped_file_ranges) {
     if (region_begin >= mapped_range.region_begin &&
+        region_begin < mapped_range.region_end &&
         region_end <= mapped_range.region_end) {
       switch (deallocation_type) {
         case DeallocationType::kDecommit:
@@ -263,8 +290,25 @@ bool DeallocFixed(void* base_address, size_t length,
   switch (deallocation_type) {
     case DeallocationType::kDecommit:
       return Protect(base_address, length, PageAccess::kNoAccess);
-    case DeallocationType::kRelease:
-      return munmap(base_address, length) == 0;
+    case DeallocationType::kRelease: {
+      // memory_win.cc passes length 0 for MEM_RELEASE; munmap rejects 0.
+      const size_t recorded = TakeReservationLength(base_address);
+      const size_t release_length = length ? length : recorded;
+      if (!release_length) {
+        XELOGE(
+            "DeallocFixed: release of {} with length 0, but that address is "
+            "not a known reservation; refusing to guess",
+            base_address);
+        return false;
+      }
+      if (munmap(base_address, release_length) != 0) {
+        if (recorded) {
+          RememberReservation(base_address, recorded);
+        }
+        return false;
+      }
+      return true;
+    }
     default:
       assert_unhandled_case(deallocation_type);
   }
@@ -274,7 +318,14 @@ bool Protect(void* base_address, size_t length, PageAccess access,
              PageAccess* out_old_access) {
   if (out_old_access) {
     size_t length_copy = length;
-    QueryProtect(base_address, length_copy, *out_old_access);
+    if (!QueryProtect(base_address, length_copy, *out_old_access)) {
+      // Fail closed: callers restore whatever this reports.
+      *out_old_access = PageAccess::kNoAccess;
+      XELOGW(
+          "Protect: could not read the current protection of {}; reporting "
+          "kNoAccess",
+          base_address);
+    }
   }
 
   uint32_t prot = ToPosixProtectFlags(access);
@@ -287,6 +338,8 @@ bool Protect(void* base_address, size_t length, PageAccess access,
 }
 
 bool QueryProtect(void* base_address, size_t& length, PageAccess& access_out) {
+  access_out = PageAccess::kNoAccess;
+  length = 0;
 #if XE_PLATFORM_MAC
   mach_vm_address_t address = reinterpret_cast<mach_vm_address_t>(base_address);
   mach_vm_size_t region_size = 0;
@@ -360,6 +413,7 @@ bool QueryProtect(void* base_address, size_t& length, PageAccess& access_out) {
             access_out == ToXeniaProtectFlags(next_protection)) {
           length =
               next_map_region_end - reinterpret_cast<uintptr_t>(base_address);
+          map_region_end = next_map_region_end;
           continue;
         }
         break;
@@ -418,7 +472,7 @@ FileMappingHandle CreateFileMappingHandle(const std::filesystem::path& path,
       assert_always();
       return kFileMappingHandleInvalid;
   }
-  oflag |= O_CREAT;
+  oflag |= O_CREAT | O_EXCL;
 
 #if XE_PLATFORM_MAC
   std::string shm_name = "/" + path.filename().string();
@@ -428,7 +482,7 @@ FileMappingHandle CreateFileMappingHandle(const std::filesystem::path& path,
     std::snprintf(hash_buf, sizeof(hash_buf), "/%016zx", h);
     shm_name = hash_buf;
   }
-  int ret = shm_open(shm_name.c_str(), oflag, 0777);
+  int ret = shm_open(shm_name.c_str(), oflag, 0600);
   if (ret < 0) {
     XELOGE("shm_open({}) failed: {} ({})", shm_name, strerror(errno), errno);
     return kFileMappingHandleInvalid;
@@ -475,7 +529,7 @@ FileMappingHandle CreateFileMappingHandle(const std::filesystem::path& path,
            path.string(), strerror(errno), errno);
   }
 #endif  // XE_PLATFORM_GNU_LINUX
-  int ret = shm_open(full_path.c_str(), oflag, 0777);
+  int ret = shm_open(full_path.c_str(), oflag, 0600);
   if (ret < 0) {
     XELOGE("shm_open({}) failed: {} ({})", full_path.string(), strerror(errno),
            errno);

--- a/src/xenia/base/system_mac.cc
+++ b/src/xenia/base/system_mac.cc
@@ -7,22 +7,43 @@
  ******************************************************************************
  */
 
+#include <crt_externs.h>
+#include <spawn.h>
+#include <sys/wait.h>
+
 #include <cstdlib>
+#include <string>
+#include <vector>
 
 #include "xenia/base/system.h"
 
 namespace xe {
+namespace {
+
+void SpawnAndWait(const std::vector<std::string>& args) {
+  std::vector<char*> argv;
+  argv.reserve(args.size() + 1);
+  for (const auto& arg : args) {
+    argv.push_back(const_cast<char*>(arg.c_str()));
+  }
+  argv.push_back(nullptr);
+  pid_t pid = 0;
+  if (posix_spawnp(&pid, argv[0], nullptr, nullptr, argv.data(),
+                   *_NSGetEnviron())) {
+    return;
+  }
+  int status = 0;
+  waitpid(pid, &status, 0);
+}
+
+}  // namespace
 
 void LaunchWebBrowser(const std::string_view url) {
-  auto cmd = std::string("open ");
-  cmd.append(url);
-  system(cmd.c_str());
+  SpawnAndWait({"open", std::string(url)});
 }
 
 void LaunchFileExplorer(const std::filesystem::path& path) {
-  auto cmd = std::string("open ");
-  cmd.append(path.string());
-  system(cmd.c_str());
+  SpawnAndWait({"open", path.string()});
 }
 
 void ShowSimpleMessageBox(SimpleMessageBoxType type, std::string_view message) {
@@ -39,22 +60,33 @@ void ShowSimpleMessageBox(SimpleMessageBoxType type, std::string_view message) {
       icon = "stop";
       break;
   }
-  // Use osascript to display a native macOS dialog.
-  auto cmd = std::string("osascript -e 'display dialog \"");
-  // Escape double quotes in the message.
+  std::string script = "display dialog \"";
+  // A raw newline is a syntax error inside an AppleScript string.
   for (char c : message) {
-    if (c == '"') {
-      cmd += "\\\"";
-    } else if (c == '\\') {
-      cmd += "\\\\";
-    } else {
-      cmd += c;
+    switch (c) {
+      case '"':
+      case '\\':
+        script += '\\';
+        script += c;
+        break;
+      case '\n':
+        script += "\\n";
+        break;
+      case '\r':
+        script += "\\r";
+        break;
+      case '\t':
+        script += "\\t";
+        break;
+      default:
+        script += c;
+        break;
     }
   }
-  cmd += "\" with icon ";
-  cmd += icon;
-  cmd += " buttons {\"OK\"} default button \"OK\" with title \"Xenia\"'";
-  system(cmd.c_str());
+  script += "\" with icon ";
+  script += icon;
+  script += " buttons {\"OK\"} default button \"OK\" with title \"Xenia\"";
+  SpawnAndWait({"osascript", "-e", script});
 }
 
 bool SetProcessPriorityClass(const uint32_t priority_class) { return true; }

--- a/src/xenia/cpu/ppc/ppc_context.h
+++ b/src/xenia/cpu/ppc/ppc_context.h
@@ -458,8 +458,8 @@ typedef struct alignas(64) PPCContext_s {
     }
 #else
     // Match vE0000000 PhysicalHeap shift (see Memory::TranslateVirtual).
-    if (xe::memory::allocation_granularity() > 0x1000 &&
-        guest_address >= 0xE0000000u) {
+    if (guest_address >= 0xE0000000u &&
+        xe::memory::allocation_granularity() > 0x1000) {
       host_address += 0x1000;
     }
 #endif

--- a/src/xenia/gpu/shared_memory.cc
+++ b/src/xenia/gpu/shared_memory.cc
@@ -102,7 +102,8 @@ void SharedMemory::ShutdownCommon() {
 
   // One AllocFixed backs both flag arrays; valid_ is its base pointer.
   if (system_page_flags_valid_) {
-    memory::DeallocFixed(system_page_flags_valid_, 0,
+    memory::DeallocFixed(system_page_flags_valid_,
+                         num_system_page_flags_ * 2 * sizeof(uint64_t),
                          memory::DeallocationType::kRelease);
     system_page_flags_valid_ = nullptr;
   }

--- a/src/xenia/vfs/devices/host_path_device.cc
+++ b/src/xenia/vfs/devices/host_path_device.cc
@@ -129,6 +129,29 @@ uint64_t StfsSingleFileContainerSize(uint64_t payload_size) {
 }  // namespace
 
 void HostPathDevice::PopulateEntry(HostPathEntry* parent_entry) {
+  std::vector<std::filesystem::path> ancestors;
+  PopulateEntry(parent_entry, ancestors);
+}
+
+void HostPathDevice::PopulateEntry(
+    HostPathEntry* parent_entry,
+    std::vector<std::filesystem::path>& ancestors) {
+  std::error_code ec;
+  auto canonical_self =
+      std::filesystem::canonical(parent_entry->host_path(), ec);
+  if (!ec) {
+    for (const auto& seen : ancestors) {
+      if (seen == canonical_self) {
+        XELOGW(
+            "HostPathDevice: {} is already on the path being walked; not "
+            "following it again",
+            xe::path_to_utf8(parent_entry->host_path()));
+        return;
+      }
+    }
+    ancestors.push_back(canonical_self);
+  }
+
   auto child_infos = xe::filesystem::ListFiles(parent_entry->host_path());
   for (auto& child_info : child_infos) {
     // Xenia bookkeeping, never part of the package the console hands out.
@@ -170,8 +193,12 @@ void HostPathDevice::PopulateEntry(HostPathEntry* parent_entry) {
     parent_entry->children_.push_back(std::unique_ptr<Entry>(child));
 
     if (child_info.type == xe::filesystem::FileInfo::Type::kDirectory) {
-      PopulateEntry(child);
+      PopulateEntry(child, ancestors);
     }
+  }
+
+  if (!ec) {
+    ancestors.pop_back();
   }
 }
 

--- a/src/xenia/vfs/devices/host_path_device.h
+++ b/src/xenia/vfs/devices/host_path_device.h
@@ -10,7 +10,9 @@
 #ifndef XENIA_VFS_DEVICES_HOST_PATH_DEVICE_H_
 #define XENIA_VFS_DEVICES_HOST_PATH_DEVICE_H_
 
+#include <filesystem>
 #include <string>
+#include <vector>
 
 #include "xenia/vfs/device.h"
 
@@ -51,6 +53,9 @@ class HostPathDevice : public Device {
 
  private:
   void PopulateEntry(HostPathEntry* parent_entry);
+  // Canonical paths on the recursion stack, so a directory symlink cycle ends.
+  void PopulateEntry(HostPathEntry* parent_entry,
+                     std::vector<std::filesystem::path>& ancestors);
 
   std::string name_;
   std::filesystem::path host_path_;


### PR DESCRIPTION
Memory (memory_posix.cc, gpu/shared_memory.cc, cpu/ppc/ppc_context.h).
page_size() now reads getpagesize() once; it sits on the guest address
translation path through allocation_granularity(). With that, the [CPU]
hunk in PPCContext::TranslateVirtual tests the address before calling
allocation_granularity(), so the common path skips the call.

DeallocFixed(kRelease) accepts a length of 0. memory_win.cc forces
length = 0 for MEM_RELEASE and processor.cc releases that way, but
munmap rejects a zero length, so those mappings leaked. AllocFixed
records every reservation it mmaps (the kCommit path returns before the
record), and a length-0 release takes the recorded length; the record
is looked up and removed under one lock so a concurrent AllocFixed that
is handed the freed address cannot lose its own record. If the release
fails the record is restored. The mapped-file range test is now
half-open, so a length-0 release cannot be captured by a file mapping
that ends exactly at that address. SharedMemory::ShutdownCommon passes
its real length. Protect() fails closed (kNoAccess, logged) when
QueryProtect cannot read the current protection instead of leaving the
out parameter unset; QueryProtect initialises its outputs and, on
Linux, advances the merge end so more than two regions can coalesce.

CreateFileMappingHandle opens with O_EXCL and mode 0600 instead of
O_CREAT and 0777, so an existing object is never adopted and other
users cannot map the guest's memory. Mapping names are per run
(xenia_memory_{tick}, xenia_code_cache_{tick}); on Linux this only
reaches the shm_open fallback selected by --use_shm_open.

Mapped files (mapped_memory_posix.cc). A read-write mapping that
extends past the end of the file grows the file with ftruncate, as
CreateFileMapping does on Win32; Emulator::SaveToFile relies on that
and mmap past EOF faulted with SIGBUS on first touch. An offset that is
not page aligned is aligned down and the mapping lengthened, and the
aligned base and length are kept for munmap and msync.

Files (filesystem_posix.cc, vfs/devices/host_path_device.*). Net
effect of the append changes: kFileAppendData counts as write intent,
O_APPEND is set only when append is the sole write right requested
(Win32 FILE_APPEND_DATA without FILE_WRITE_DATA), such handles write
with write() and every other handle keeps pwrite(); Linux's pwrite(2)
ignores the offset on an O_APPEND descriptor, so a read-write handle
must not carry it. GetUserFolder checks getpwuid_r's result before
dereferencing it and falls back to cwd/.local/share when there is no
HOME and no passwd entry. ListFilesUnsorted classifies entries from
stat (symlinked directories were listed as files), falls back to lstat
and then zeroes the struct when stat fails. HostPathDevice::
PopulateEntry keeps the canonical paths on its recursion stack and does
not follow a directory symlink back into one of them.

Clock (clock_posix.cc). QueryHostInterruptTime returns 100 ns units on
every POSIX host, matching the Windows implementation; it returned raw
host ticks, so the guest's KeQueryInterruptTime ran 100x fast on
Linux's 1 GHz counter and 2.4x fast on a 24 MHz Apple Silicon
timebase. This is a Linux-visible timing change. The conversion no
longer overflows on long uptimes and reads the tick frequency once.

Process (system_mac.cc). LaunchWebBrowser, LaunchFileExplorer and
ShowSimpleMessageBox spawn their program with posix_spawnp and an
argument vector instead of system() with a concatenated command line,
so a URL, path or message can no longer be read as shell syntax; the
AppleScript escapes quotes, backslashes and line breaks.

Evidence: correctness. The PPC test corpus (xenia-cpu-ppc-tests) is
unaffected by this commit and serves only as a regression gate. The
Linux-specific hunks (QueryProtect merge, memfd/shm_open path) are not
compiled on the macOS host this was written on and need a Linux build.