### PR TITLE
[A64] Remap on the effective address and shorten guest addressing

### DIFF
--- a/src/xenia/cpu/backend/a64/a64_seq_memory.cc
+++ b/src/xenia/cpu/backend/a64/a64_seq_memory.cc
@@ -184,128 +184,358 @@ static T MMIOAwareLoad(void* _ctx, unsigned int guestaddr) {
   return value;
 }
 
+// MMIO is the top 4 MiB of guest space: top ten address bits 0111111111.
+static void EmitMmioRangeTest(A64Emitter& e,
+                              Xbyak_aarch64::Label& normal_access) {
+  e.lsr(e.w0, e.w17, 22);
+  e.cmp(e.w0, 0x1FFu);
+  e.b_near(Xbyak_aarch64::NE, normal_access);
+}
+
+struct GuestAddress {
+  const I64Op& base;
+  const I64Op* displacement;  // nullptr for the plain forms.
+};
+
+template <typename Fn>
+static void EmitAccess(A64Emitter& e, const GuestAddress& addr,
+                       Fn&& emit_access) {
+  if (addr.displacement) {
+    EmitGuestMemAccessOffset(e, addr.base, *addr.displacement, emit_access);
+  } else {
+    EmitGuestMemAccess(e, addr.base, emit_access);
+  }
+}
+
+static XReg ComputeTraceAddress(A64Emitter& e, const GuestAddress& addr) {
+  return addr.displacement
+             ? ComputeMemoryAddressOffset(e, addr.base, *addr.displacement)
+             : ComputeMemoryAddress(e, addr.base);
+}
+
+template <typename Op>
+static void MoveToW(A64Emitter& e, const WReg& dst, const Op& op) {
+  if (op.is_constant) {
+    e.mov(dst, static_cast<uint64_t>(static_cast<uint32_t>(op.constant())));
+  } else {
+    e.mov(dst, WReg(op.reg().getIdx()));
+  }
+}
+
+static void MoveGuestAddressToW1(A64Emitter& e, const GuestAddress& addr) {
+  MoveToW(e, e.w1, addr.base);
+  if (addr.displacement) {
+    MoveToW(e, e.w17, *addr.displacement);
+    e.add(e.w1, e.w1, e.w17);
+  }
+}
+
+static void MoveGuestAddressToW17(A64Emitter& e, const GuestAddress& addr) {
+  MoveToW(e, e.w17, addr.base);
+  if (!addr.displacement) {
+    return;
+  }
+  const I64Op& displacement = *addr.displacement;
+  if (displacement.is_constant) {
+    const uint32_t imm = static_cast<uint32_t>(displacement.constant());
+    if (imm != 0) {
+      e.mov(e.w0, static_cast<uint64_t>(imm));
+      e.add(e.w17, e.w17, e.w0);
+    }
+  } else {
+    e.add(e.w17, e.w17, WReg(displacement.reg().getIdx()));
+  }
+}
+
+static void* MmioAwareLoad32(const hir::Instr* instr) {
+  return (instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP)
+             ? (void*)&MMIOAwareLoad<uint32_t, true>
+             : (void*)&MMIOAwareLoad<uint32_t, false>;
+}
+static void* MmioAwareStore32(const hir::Instr* instr) {
+  return (instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP)
+             ? (void*)&MMIOAwareStore<uint32_t, true>
+             : (void*)&MMIOAwareStore<uint32_t, false>;
+}
+
+template <typename MmioFn, typename AccessFn>
+static void EmitInlineMmioCheck(A64Emitter& e, MmioFn&& emit_mmio,
+                                AccessFn&& emit_access) {
+  auto& normal_access = e.NewCachedLabel();
+  auto& done = e.NewCachedLabel();
+  EmitMmioRangeTest(e, normal_access);
+  emit_mmio();
+  e.b(done);
+  e.L(normal_access);
+  emit_access();
+  e.L(done);
+}
+
+template <typename T, typename SrcOp, typename ScratchReg, typename ConstantFn,
+          typename SwapFn, typename StoreFn>
+static void EmitStoreScalar(A64Emitter& e, const hir::Instr* instr,
+                            const SrcOp& src, const ScratchReg& scratch,
+                            ConstantFn&& constant_bits,
+                            SwapFn&& swap_into_scratch, StoreFn&& store) {
+  const bool swap = (instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) != 0;
+  if (src.is_constant) {
+    const T value = constant_bits();
+    e.mov(scratch, static_cast<uint64_t>(swap ? xe::byte_swap(value) : value));
+    store(scratch);
+  } else if (swap) {
+    swap_into_scratch();
+    store(scratch);
+  } else {
+    store(src);
+  }
+}
+
+// ============================================================================
+// Load and store bodies shared by the plain and the *_OFFSET sequences
+// ============================================================================
+static void EmitLoadI8(A64Emitter& e, const WReg& dest,
+                       const GuestAddress& addr) {
+  EmitAccess(e, addr, [&](const auto& adr) { e.ldrb(dest, adr); });
+  if (IsTracingData()) {
+    auto trace_addr = ComputeTraceAddress(e, addr);
+    e.mov(e.w2, dest);
+    e.mov(e.w1, WReg(trace_addr.getIdx()));
+    e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadI8));
+  }
+}
+
+static void EmitLoadI16(A64Emitter& e, const hir::Instr* instr,
+                        const WReg& dest, const GuestAddress& addr) {
+  EmitAccess(e, addr, [&](const auto& adr) { e.ldrh(dest, adr); });
+  if (instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
+    e.rev16(dest, dest);
+  }
+  if (IsTracingData()) {
+    auto trace_addr = ComputeTraceAddress(e, addr);
+    e.mov(e.w2, dest);
+    e.mov(e.w1, WReg(trace_addr.getIdx()));
+    e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadI16));
+  }
+}
+
+static void EmitLoadI32(A64Emitter& e, const hir::Instr* instr,
+                        const WReg& dest, const GuestAddress& addr) {
+  void* mmio_fn = MmioAwareLoad32(instr);
+  if (IsPossibleMMIOInstruction(e, instr)) {
+    MoveGuestAddressToW1(e, addr);
+    e.CallNativeSafe(mmio_fn);
+    e.mov(dest, e.w0);
+    return;
+  }
+  auto load = [&] {
+    EmitAccess(e, addr, [&](const auto& adr) { e.ldr(dest, adr); });
+    if (instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
+      e.rev(dest, dest);
+    }
+  };
+  if (cvars::emit_inline_mmio_checks && !IsTracingData()) {
+    MoveGuestAddressToW17(e, addr);
+    EmitInlineMmioCheck(
+        e,
+        [&] {
+          e.mov(e.w1, e.w17);
+          e.CallNativeSafe(mmio_fn);
+          e.mov(dest, e.w0);
+        },
+        load);
+  } else {
+    load();
+    if (IsTracingData()) {
+      auto trace_addr = ComputeTraceAddress(e, addr);
+      e.mov(e.w2, dest);
+      e.mov(e.w1, WReg(trace_addr.getIdx()));
+      e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadI32));
+    }
+  }
+}
+
+static void EmitLoadI64(A64Emitter& e, const hir::Instr* instr,
+                        const XReg& dest, const GuestAddress& addr) {
+  EmitAccess(e, addr, [&](const auto& adr) { e.ldr(dest, adr); });
+  if (instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
+    e.rev(dest, dest);
+  }
+  if (IsTracingData()) {
+    auto trace_addr = ComputeTraceAddress(e, addr);
+    e.mov(e.x2, dest);
+    e.mov(e.w1, WReg(trace_addr.getIdx()));
+    e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadI64));
+  }
+}
+
+static void EmitStoreI8(A64Emitter& e, const GuestAddress& addr,
+                        const I8Op& value) {
+  EmitAccess(e, addr, [&](const auto& adr) {
+    if (value.is_constant) {
+      e.mov(e.w17, static_cast<uint64_t>(value.constant() & 0xFF));
+      e.strb(e.w17, adr);
+    } else {
+      e.strb(value, adr);
+    }
+  });
+  if (IsTracingData()) {
+    auto trace_addr = ComputeTraceAddress(e, addr);
+    e.ldrb(e.w2, ptr(e.GetMembaseReg(), trace_addr));
+    e.mov(e.w1, WReg(trace_addr.getIdx()));
+    e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreI8));
+  }
+}
+
+static void EmitStoreI16(A64Emitter& e, const hir::Instr* instr,
+                         const GuestAddress& addr, const I16Op& value) {
+  EmitAccess(e, addr, [&](const auto& adr) {
+    EmitStoreScalar<uint16_t>(
+        e, instr, value, e.w17,
+        [&] { return static_cast<uint16_t>(value.constant()); },
+        [&] { e.rev16(e.w17, value); },
+        [&](const auto& reg) { e.strh(reg, adr); });
+  });
+  if (IsTracingData()) {
+    auto trace_addr = ComputeTraceAddress(e, addr);
+    e.ldrh(e.w2, ptr(e.GetMembaseReg(), trace_addr));
+    e.mov(e.w1, WReg(trace_addr.getIdx()));
+    e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreI16));
+  }
+}
+
+static void EmitStoreI32(A64Emitter& e, const hir::Instr* instr,
+                         const GuestAddress& addr, const I32Op& value) {
+  void* mmio_fn = MmioAwareStore32(instr);
+  if (IsPossibleMMIOInstruction(e, instr)) {
+    MoveGuestAddressToW1(e, addr);
+    MoveToW(e, e.w2, value);
+    e.CallNativeSafe(mmio_fn);
+    return;
+  }
+  auto store = [&] {
+    EmitAccess(e, addr, [&](const auto& adr) {
+      EmitStoreScalar<uint32_t>(
+          e, instr, value, e.w17,
+          [&] { return static_cast<uint32_t>(value.constant()); },
+          [&] { e.rev(e.w17, value); },
+          [&](const auto& reg) { e.str(reg, adr); });
+    });
+  };
+  if (cvars::emit_inline_mmio_checks && !IsTracingData()) {
+    MoveGuestAddressToW17(e, addr);
+    EmitInlineMmioCheck(
+        e,
+        [&] {
+          // The value goes to w2 before w1 in case it lives in w1.
+          MoveToW(e, e.w2, value);
+          e.mov(e.w1, e.w17);
+          e.CallNativeSafe(mmio_fn);
+        },
+        store);
+  } else {
+    store();
+    if (IsTracingData()) {
+      auto trace_addr = ComputeTraceAddress(e, addr);
+      e.ldr(e.w2, ptr(e.GetMembaseReg(), trace_addr));
+      e.mov(e.w1, WReg(trace_addr.getIdx()));
+      e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreI32));
+    }
+  }
+}
+
+static void EmitStoreI64(A64Emitter& e, const hir::Instr* instr,
+                         const GuestAddress& addr, const I64Op& value) {
+  EmitAccess(e, addr, [&](const auto& adr) {
+    EmitStoreScalar<uint64_t>(
+        e, instr, value, e.x17,
+        [&] { return static_cast<uint64_t>(value.constant()); },
+        [&] { e.rev(e.x17, value); },
+        [&](const auto& reg) { e.str(reg, adr); });
+  });
+  if (IsTracingData()) {
+    auto trace_addr = ComputeTraceAddress(e, addr);
+    e.ldr(e.x2, ptr(e.GetMembaseReg(), trace_addr));
+    e.mov(e.w1, WReg(trace_addr.getIdx()));
+    e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreI64));
+  }
+}
+
+static void EmitStoreF32(A64Emitter& e, const hir::Instr* instr,
+                         const GuestAddress& addr, const F32Op& value) {
+  EmitAccess(e, addr, [&](const auto& adr) {
+    EmitStoreScalar<uint32_t>(
+        e, instr, value, e.w17,
+        [&] { return static_cast<uint32_t>(value.value->constant.i32); },
+        [&] {
+          e.fmov(e.w17, value);
+          e.rev(e.w17, e.w17);
+        },
+        [&](const auto& reg) { e.str(reg, adr); });
+  });
+  if (IsTracingData()) {
+    auto trace_addr = ComputeTraceAddress(e, addr);
+    e.ldr(e.s0, ptr(e.GetMembaseReg(), trace_addr));
+    e.mov(e.w1, WReg(trace_addr.getIdx()));
+    e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreF32));
+  }
+}
+
+static void EmitStoreF64(A64Emitter& e, const hir::Instr* instr,
+                         const GuestAddress& addr, const F64Op& value) {
+  EmitAccess(e, addr, [&](const auto& adr) {
+    EmitStoreScalar<uint64_t>(
+        e, instr, value, e.x17,
+        [&] { return static_cast<uint64_t>(value.value->constant.i64); },
+        [&] {
+          e.fmov(e.x17, value);
+          e.rev(e.x17, e.x17);
+        },
+        [&](const auto& reg) { e.str(reg, adr); });
+  });
+  if (IsTracingData()) {
+    auto trace_addr = ComputeTraceAddress(e, addr);
+    e.ldr(e.d0, ptr(e.GetMembaseReg(), trace_addr));
+    e.mov(e.w1, WReg(trace_addr.getIdx()));
+    e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreF64));
+  }
+}
+
 // ============================================================================
 // OPCODE_LOAD
 // ============================================================================
 struct LOAD_I8 : Sequence<LOAD_I8, I<OPCODE_LOAD, I8Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr = ComputeMemoryAddress(e, i.src1);
-    e.ldrb(i.dest, ptr(e.GetMembaseReg(), addr));
-    if (IsTracingData()) {
-      addr = ComputeMemoryAddress(e, i.src1);
-      e.mov(e.w2, i.dest);
-      e.mov(e.w1, WReg(addr.getIdx()));
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadI8));
-    }
+    EmitLoadI8(e, i.dest, {i.src1, nullptr});
   }
 };
 struct LOAD_I16 : Sequence<LOAD_I16, I<OPCODE_LOAD, I16Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr = ComputeMemoryAddress(e, i.src1);
-    e.ldrh(i.dest, ptr(e.GetMembaseReg(), addr));
-    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-      e.rev16(i.dest, i.dest);
-    }
-    if (IsTracingData()) {
-      addr = ComputeMemoryAddress(e, i.src1);
-      e.mov(e.w2, i.dest);
-      e.mov(e.w1, WReg(addr.getIdx()));
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadI16));
-    }
+    EmitLoadI16(e, i.instr, i.dest, {i.src1, nullptr});
   }
 };
 struct LOAD_I32 : Sequence<LOAD_I32, I<OPCODE_LOAD, I32Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    if (IsPossibleMMIOInstruction(e, i.instr)) {
-      void* mmio_fn = (void*)&MMIOAwareLoad<uint32_t, false>;
-      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-        mmio_fn = (void*)&MMIOAwareLoad<uint32_t, true>;
-      }
-      if (i.src1.is_constant) {
-        e.mov(e.w1,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
-      } else {
-        e.mov(e.w1, WReg(i.src1.reg().getIdx()));
-      }
-      e.CallNativeSafe(mmio_fn);
-      e.mov(i.dest, e.w0);
-      return;
-    }
-    if (cvars::emit_inline_mmio_checks && !IsTracingData()) {
-      if (i.src1.is_constant) {
-        e.mov(e.w17,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
-      } else {
-        e.mov(e.w17, WReg(i.src1.reg().getIdx()));
-      }
-      auto& normal_access = e.NewCachedLabel();
-      auto& done = e.NewCachedLabel();
-      e.mov(e.w0, 0x7FC00000u);
-      e.cmp(e.w17, e.w0);
-      e.b(LO, normal_access);
-      e.mov(e.w0, 0x7FFFFFFFu);
-      e.cmp(e.w17, e.w0);
-      e.b(HI, normal_access);
-      // MMIO path
-      void* mmio_fn = (void*)&MMIOAwareLoad<uint32_t, false>;
-      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-        mmio_fn = (void*)&MMIOAwareLoad<uint32_t, true>;
-      }
-      e.mov(e.w1, e.w17);
-      e.CallNativeSafe(mmio_fn);
-      e.mov(i.dest, e.w0);
-      e.b(done);
-      e.L(normal_access);
-      {
-        auto addr = ComputeMemoryAddress(e, i.src1);
-        e.ldr(i.dest, ptr(e.GetMembaseReg(), addr));
-        if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-          e.rev(i.dest, i.dest);
-        }
-      }
-      e.L(done);
-    } else {
-      auto addr = ComputeMemoryAddress(e, i.src1);
-      e.ldr(i.dest, ptr(e.GetMembaseReg(), addr));
-      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-        e.rev(i.dest, i.dest);
-      }
-      if (IsTracingData()) {
-        addr = ComputeMemoryAddress(e, i.src1);
-        e.mov(e.w2, i.dest);
-        e.mov(e.w1, WReg(addr.getIdx()));
-        e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadI32));
-      }
-    }
+    EmitLoadI32(e, i.instr, i.dest, {i.src1, nullptr});
   }
 };
 struct LOAD_I64 : Sequence<LOAD_I64, I<OPCODE_LOAD, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr = ComputeMemoryAddress(e, i.src1);
-    e.ldr(i.dest, ptr(e.GetMembaseReg(), addr));
-    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-      e.rev(i.dest, i.dest);
-    }
-    if (IsTracingData()) {
-      addr = ComputeMemoryAddress(e, i.src1);
-      e.mov(e.x2, i.dest);
-      e.mov(e.w1, WReg(addr.getIdx()));
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadI64));
-    }
+    EmitLoadI64(e, i.instr, i.dest, {i.src1, nullptr});
   }
 };
 struct LOAD_F32 : Sequence<LOAD_F32, I<OPCODE_LOAD, F32Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr = ComputeMemoryAddress(e, i.src1);
-    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-      e.ldr(e.w0, ptr(e.GetMembaseReg(), addr));
-      e.rev(e.w0, e.w0);
-      e.fmov(i.dest, e.w0);
-    } else {
-      e.ldr(i.dest, ptr(e.GetMembaseReg(), addr));
-    }
+    EmitGuestMemAccess(e, i.src1, [&](const auto& adr) {
+      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
+        e.ldr(e.w0, adr);
+        e.rev(e.w0, e.w0);
+        e.fmov(i.dest, e.w0);
+      } else {
+        e.ldr(i.dest, adr);
+      }
+    });
     if (IsTracingData()) {
-      addr = ComputeMemoryAddress(e, i.src1);
+      auto addr = ComputeMemoryAddress(e, i.src1);
       e.mov(VReg(0).b16, VReg(i.dest.reg().getIdx()).b16);
       e.mov(e.w1, WReg(addr.getIdx()));
       e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadF32));
@@ -314,16 +544,17 @@ struct LOAD_F32 : Sequence<LOAD_F32, I<OPCODE_LOAD, F32Op, I64Op>> {
 };
 struct LOAD_F64 : Sequence<LOAD_F64, I<OPCODE_LOAD, F64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr = ComputeMemoryAddress(e, i.src1);
-    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-      e.ldr(e.x0, ptr(e.GetMembaseReg(), addr));
-      e.rev(e.x0, e.x0);
-      e.fmov(i.dest, e.x0);
-    } else {
-      e.ldr(i.dest, ptr(e.GetMembaseReg(), addr));
-    }
+    EmitGuestMemAccess(e, i.src1, [&](const auto& adr) {
+      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
+        e.ldr(e.x0, adr);
+        e.rev(e.x0, e.x0);
+        e.fmov(i.dest, e.x0);
+      } else {
+        e.ldr(i.dest, adr);
+      }
+    });
     if (IsTracingData()) {
-      addr = ComputeMemoryAddress(e, i.src1);
+      auto addr = ComputeMemoryAddress(e, i.src1);
       e.mov(VReg(0).b16, VReg(i.dest.reg().getIdx()).b16);
       e.mov(e.w1, WReg(addr.getIdx()));
       e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadF64));
@@ -332,15 +563,14 @@ struct LOAD_F64 : Sequence<LOAD_F64, I<OPCODE_LOAD, F64Op, I64Op>> {
 };
 struct LOAD_V128 : Sequence<LOAD_V128, I<OPCODE_LOAD, V128Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr = ComputeMemoryAddress(e, i.src1);
-    e.ldr(i.dest, ptr(e.GetMembaseReg(), addr));
+    EmitGuestMemAccess(e, i.src1, [&](const auto& adr) { e.ldr(i.dest, adr); });
     if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
       // Reverse bytes within each 32-bit word (PPC BE -> ARM64 LE).
       auto idx = i.dest.reg().getIdx();
       e.rev32(VReg16B(idx), VReg16B(idx));
     }
     if (IsTracingData()) {
-      addr = ComputeMemoryAddress(e, i.src1);
+      auto addr = ComputeMemoryAddress(e, i.src1);
       e.add(e.x2, e.GetMembaseReg(), addr);
       e.mov(e.w1, WReg(addr.getIdx()));
       e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadV128));
@@ -355,253 +585,45 @@ EMITTER_OPCODE_TABLE(OPCODE_LOAD, LOAD_I8, LOAD_I16, LOAD_I32, LOAD_I64,
 // ============================================================================
 struct STORE_I8 : Sequence<STORE_I8, I<OPCODE_STORE, VoidOp, I64Op, I8Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr = ComputeMemoryAddress(e, i.src1);
-    if (i.src2.is_constant) {
-      e.mov(e.w17, static_cast<uint64_t>(i.src2.constant() & 0xFF));
-      e.strb(e.w17, ptr(e.GetMembaseReg(), addr));
-    } else {
-      e.strb(i.src2, ptr(e.GetMembaseReg(), addr));
-    }
-    if (IsTracingData()) {
-      addr = ComputeMemoryAddress(e, i.src1);
-      e.ldrb(e.w2, ptr(e.GetMembaseReg(), addr));
-      e.mov(e.w1, WReg(addr.getIdx()));
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreI8));
-    }
+    EmitStoreI8(e, {i.src1, nullptr}, i.src2);
   }
 };
 struct STORE_I16 : Sequence<STORE_I16, I<OPCODE_STORE, VoidOp, I64Op, I16Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr = ComputeMemoryAddress(e, i.src1);
-    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-      if (i.src2.is_constant) {
-        uint16_t val = xe::byte_swap(static_cast<uint16_t>(i.src2.constant()));
-        e.mov(e.w17, static_cast<uint64_t>(val));
-      } else {
-        e.rev16(e.w17, i.src2);
-      }
-      e.strh(e.w17, ptr(e.GetMembaseReg(), addr));
-    } else {
-      if (i.src2.is_constant) {
-        e.mov(e.w17, static_cast<uint64_t>(i.src2.constant() & 0xFFFF));
-        e.strh(e.w17, ptr(e.GetMembaseReg(), addr));
-      } else {
-        e.strh(i.src2, ptr(e.GetMembaseReg(), addr));
-      }
-    }
-    if (IsTracingData()) {
-      addr = ComputeMemoryAddress(e, i.src1);
-      e.ldrh(e.w2, ptr(e.GetMembaseReg(), addr));
-      e.mov(e.w1, WReg(addr.getIdx()));
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreI16));
-    }
+    EmitStoreI16(e, i.instr, {i.src1, nullptr}, i.src2);
   }
 };
 struct STORE_I32 : Sequence<STORE_I32, I<OPCODE_STORE, VoidOp, I64Op, I32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    if (IsPossibleMMIOInstruction(e, i.instr)) {
-      void* mmio_fn = (void*)&MMIOAwareStore<uint32_t, false>;
-      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-        mmio_fn = (void*)&MMIOAwareStore<uint32_t, true>;
-      }
-      if (i.src1.is_constant) {
-        e.mov(e.w1,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
-      } else {
-        e.mov(e.w1, WReg(i.src1.reg().getIdx()));
-      }
-      if (i.src2.is_constant) {
-        e.mov(e.w2,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src2.constant())));
-      } else {
-        e.mov(e.w2, i.src2);
-      }
-      e.CallNativeSafe(mmio_fn);
-      return;
-    }
-    if (cvars::emit_inline_mmio_checks && !IsTracingData()) {
-      if (i.src1.is_constant) {
-        e.mov(e.w17,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
-      } else {
-        e.mov(e.w17, WReg(i.src1.reg().getIdx()));
-      }
-      auto& normal_access = e.NewCachedLabel();
-      auto& done = e.NewCachedLabel();
-      e.mov(e.w0, 0x7FC00000u);
-      e.cmp(e.w17, e.w0);
-      e.b(LO, normal_access);
-      e.mov(e.w0, 0x7FFFFFFFu);
-      e.cmp(e.w17, e.w0);
-      e.b(HI, normal_access);
-      // MMIO path — copy value to w2 before w1 in case src2 is in w1
-      void* mmio_fn = (void*)&MMIOAwareStore<uint32_t, false>;
-      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-        mmio_fn = (void*)&MMIOAwareStore<uint32_t, true>;
-      }
-      if (i.src2.is_constant) {
-        e.mov(e.w2,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src2.constant())));
-      } else {
-        e.mov(e.w2, i.src2);
-      }
-      e.mov(e.w1, e.w17);
-      e.CallNativeSafe(mmio_fn);
-      e.b(done);
-      e.L(normal_access);
-      {
-        auto addr = ComputeMemoryAddress(e, i.src1);
-        if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-          if (i.src2.is_constant) {
-            uint32_t val =
-                xe::byte_swap(static_cast<uint32_t>(i.src2.constant()));
-            e.mov(e.w17, static_cast<uint64_t>(val));
-          } else {
-            e.rev(e.w17, i.src2);
-          }
-          e.str(e.w17, ptr(e.GetMembaseReg(), addr));
-        } else {
-          if (i.src2.is_constant) {
-            e.mov(e.w17, static_cast<uint64_t>(
-                             static_cast<uint32_t>(i.src2.constant())));
-            e.str(e.w17, ptr(e.GetMembaseReg(), addr));
-          } else {
-            e.str(i.src2, ptr(e.GetMembaseReg(), addr));
-          }
-        }
-      }
-      e.L(done);
-    } else {
-      auto addr = ComputeMemoryAddress(e, i.src1);
-      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-        if (i.src2.is_constant) {
-          uint32_t val =
-              xe::byte_swap(static_cast<uint32_t>(i.src2.constant()));
-          e.mov(e.w17, static_cast<uint64_t>(val));
-        } else {
-          e.rev(e.w17, i.src2);
-        }
-        e.str(e.w17, ptr(e.GetMembaseReg(), addr));
-      } else {
-        if (i.src2.is_constant) {
-          e.mov(e.w17, static_cast<uint64_t>(
-                           static_cast<uint32_t>(i.src2.constant())));
-          e.str(e.w17, ptr(e.GetMembaseReg(), addr));
-        } else {
-          e.str(i.src2, ptr(e.GetMembaseReg(), addr));
-        }
-      }
-      if (IsTracingData()) {
-        addr = ComputeMemoryAddress(e, i.src1);
-        e.ldr(e.w2, ptr(e.GetMembaseReg(), addr));
-        e.mov(e.w1, WReg(addr.getIdx()));
-        e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreI32));
-      }
-    }
+    EmitStoreI32(e, i.instr, {i.src1, nullptr}, i.src2);
   }
 };
 struct STORE_I64 : Sequence<STORE_I64, I<OPCODE_STORE, VoidOp, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr = ComputeMemoryAddress(e, i.src1);
-    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-      if (i.src2.is_constant) {
-        uint64_t val = xe::byte_swap(static_cast<uint64_t>(i.src2.constant()));
-        e.mov(e.x17, val);
-      } else {
-        e.rev(e.x17, i.src2);
-      }
-      e.str(e.x17, ptr(e.GetMembaseReg(), addr));
-    } else {
-      if (i.src2.is_constant) {
-        e.mov(e.x17, static_cast<uint64_t>(i.src2.constant()));
-        e.str(e.x17, ptr(e.GetMembaseReg(), addr));
-      } else {
-        e.str(i.src2, ptr(e.GetMembaseReg(), addr));
-      }
-    }
-    if (IsTracingData()) {
-      addr = ComputeMemoryAddress(e, i.src1);
-      e.ldr(e.x2, ptr(e.GetMembaseReg(), addr));
-      e.mov(e.w1, WReg(addr.getIdx()));
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreI64));
-    }
+    EmitStoreI64(e, i.instr, {i.src1, nullptr}, i.src2);
   }
 };
 struct STORE_F32 : Sequence<STORE_F32, I<OPCODE_STORE, VoidOp, I64Op, F32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr = ComputeMemoryAddress(e, i.src1);
-    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-      if (i.src2.is_constant) {
-        uint32_t val =
-            xe::byte_swap(static_cast<uint32_t>(i.src2.value->constant.i32));
-        e.mov(e.w17, static_cast<uint64_t>(val));
-      } else {
-        e.fmov(e.w17, i.src2);
-        e.rev(e.w17, e.w17);
-      }
-      e.str(e.w17, ptr(e.GetMembaseReg(), addr));
-    } else {
-      if (i.src2.is_constant) {
-        e.mov(e.w17, static_cast<uint64_t>(i.src2.value->constant.i32));
-        e.str(e.w17, ptr(e.GetMembaseReg(), addr));
-      } else {
-        e.str(i.src2, ptr(e.GetMembaseReg(), addr));
-      }
-    }
-    if (IsTracingData()) {
-      addr = ComputeMemoryAddress(e, i.src1);
-      e.ldr(e.s0, ptr(e.GetMembaseReg(), addr));
-      e.mov(e.w1, WReg(addr.getIdx()));
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreF32));
-    }
+    EmitStoreF32(e, i.instr, {i.src1, nullptr}, i.src2);
   }
 };
 struct STORE_F64 : Sequence<STORE_F64, I<OPCODE_STORE, VoidOp, I64Op, F64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr = ComputeMemoryAddress(e, i.src1);
-    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-      if (i.src2.is_constant) {
-        uint64_t val =
-            xe::byte_swap(static_cast<uint64_t>(i.src2.value->constant.i64));
-        e.mov(e.x17, val);
-      } else {
-        e.fmov(e.x17, i.src2);
-        e.rev(e.x17, e.x17);
-      }
-      e.str(e.x17, ptr(e.GetMembaseReg(), addr));
-    } else {
-      if (i.src2.is_constant) {
-        e.mov(e.x17, static_cast<uint64_t>(i.src2.value->constant.i64));
-        e.str(e.x17, ptr(e.GetMembaseReg(), addr));
-      } else {
-        e.str(i.src2, ptr(e.GetMembaseReg(), addr));
-      }
-    }
-    if (IsTracingData()) {
-      addr = ComputeMemoryAddress(e, i.src1);
-      e.ldr(e.d0, ptr(e.GetMembaseReg(), addr));
-      e.mov(e.w1, WReg(addr.getIdx()));
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreF64));
-    }
+    EmitStoreF64(e, i.instr, {i.src1, nullptr}, i.src2);
   }
 };
 struct STORE_V128
     : Sequence<STORE_V128, I<OPCODE_STORE, VoidOp, I64Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr = ComputeMemoryAddress(e, i.src1);
+    int src_idx = SrcVReg(e, i.src2, 0);
     if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
       // Reverse bytes within each 32-bit word, store via scratch v0.
-      int idx = SrcVReg(e, i.src2, 0);
-      e.rev32(VReg16B(0), VReg16B(idx));
-      e.str(QReg(0), ptr(e.GetMembaseReg(), addr));
-    } else {
-      if (i.src2.is_constant) {
-        LoadV128Const(e, 0, i.src2.constant());
-        e.str(QReg(0), ptr(e.GetMembaseReg(), addr));
-      } else {
-        e.str(i.src2, ptr(e.GetMembaseReg(), addr));
-      }
+      e.rev32(VReg16B(0), VReg16B(src_idx));
+      src_idx = 0;
     }
+    EmitGuestMemAccess(e, i.src1,
+                       [&](const auto& adr) { e.str(QReg(src_idx), adr); });
     if (IsTracingData()) {
       auto trace_addr = ComputeMemoryAddress(e, i.src1);
       e.add(e.x2, e.GetMembaseReg(), trace_addr);
@@ -672,129 +694,25 @@ EMITTER_OPCODE_TABLE(OPCODE_LOAD_CLOCK, LOAD_CLOCK);
 struct LOAD_OFFSET_I8
     : Sequence<LOAD_OFFSET_I8, I<OPCODE_LOAD_OFFSET, I8Op, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-    e.ldrb(i.dest, ptr(e.GetMembaseReg(), e.x0));
-    if (IsTracingData()) {
-      AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-      e.mov(e.w2, i.dest);
-      e.mov(e.w1, e.w0);
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadI8));
-    }
+    EmitLoadI8(e, i.dest, {i.src1, &i.src2});
   }
 };
 struct LOAD_OFFSET_I16
     : Sequence<LOAD_OFFSET_I16, I<OPCODE_LOAD_OFFSET, I16Op, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-    e.ldrh(i.dest, ptr(e.GetMembaseReg(), e.x0));
-    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-      e.rev16(i.dest, i.dest);
-    }
-    if (IsTracingData()) {
-      AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-      e.mov(e.w2, i.dest);
-      e.mov(e.w1, e.w0);
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadI16));
-    }
+    EmitLoadI16(e, i.instr, i.dest, {i.src1, &i.src2});
   }
 };
 struct LOAD_OFFSET_I32
     : Sequence<LOAD_OFFSET_I32, I<OPCODE_LOAD_OFFSET, I32Op, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    if (IsPossibleMMIOInstruction(e, i.instr)) {
-      void* mmio_fn = (void*)&MMIOAwareLoad<uint32_t, false>;
-      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-        mmio_fn = (void*)&MMIOAwareLoad<uint32_t, true>;
-      }
-      if (i.src1.is_constant) {
-        e.mov(e.w1,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
-      } else {
-        e.mov(e.w1, WReg(i.src1.reg().getIdx()));
-      }
-      if (i.src2.is_constant) {
-        e.mov(e.w17,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src2.constant())));
-      } else {
-        e.mov(e.w17, WReg(i.src2.reg().getIdx()));
-      }
-      e.add(e.w1, e.w1, e.w17);
-      e.CallNativeSafe(mmio_fn);
-      e.mov(i.dest, e.w0);
-      return;
-    }
-    if (cvars::emit_inline_mmio_checks && !IsTracingData()) {
-      // Compute raw guest address (src1 + src2) in w17 for range check.
-      if (i.src1.is_constant) {
-        e.mov(e.w17,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
-      } else {
-        e.mov(e.w17, WReg(i.src1.reg().getIdx()));
-      }
-      if (i.src2.is_constant) {
-        uint32_t offset = static_cast<uint32_t>(i.src2.constant());
-        if (offset != 0) {
-          e.mov(e.w0, static_cast<uint64_t>(offset));
-          e.add(e.w17, e.w17, e.w0);
-        }
-      } else {
-        e.add(e.w17, e.w17, WReg(i.src2.reg().getIdx()));
-      }
-      auto& normal_access = e.NewCachedLabel();
-      auto& done = e.NewCachedLabel();
-      e.mov(e.w0, 0x7FC00000u);
-      e.cmp(e.w17, e.w0);
-      e.b(LO, normal_access);
-      e.mov(e.w0, 0x7FFFFFFFu);
-      e.cmp(e.w17, e.w0);
-      e.b(HI, normal_access);
-      // MMIO path
-      void* mmio_fn = (void*)&MMIOAwareLoad<uint32_t, false>;
-      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-        mmio_fn = (void*)&MMIOAwareLoad<uint32_t, true>;
-      }
-      e.mov(e.w1, e.w17);
-      e.CallNativeSafe(mmio_fn);
-      e.mov(i.dest, e.w0);
-      e.b(done);
-      e.L(normal_access);
-      {
-        AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-        e.ldr(i.dest, ptr(e.GetMembaseReg(), e.x0));
-        if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-          e.rev(i.dest, i.dest);
-        }
-      }
-      e.L(done);
-    } else {
-      AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-      e.ldr(i.dest, ptr(e.GetMembaseReg(), e.x0));
-      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-        e.rev(i.dest, i.dest);
-      }
-      if (IsTracingData()) {
-        AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-        e.mov(e.w2, i.dest);
-        e.mov(e.w1, e.w0);
-        e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadI32));
-      }
-    }
+    EmitLoadI32(e, i.instr, i.dest, {i.src1, &i.src2});
   }
 };
 struct LOAD_OFFSET_I64
     : Sequence<LOAD_OFFSET_I64, I<OPCODE_LOAD_OFFSET, I64Op, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-    e.ldr(i.dest, ptr(e.GetMembaseReg(), e.x0));
-    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-      e.rev(i.dest, i.dest);
-    }
-    if (IsTracingData()) {
-      AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-      e.mov(e.x2, i.dest);
-      e.mov(e.w1, e.w0);
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryLoadI64));
-    }
+    EmitLoadI64(e, i.instr, i.dest, {i.src1, &i.src2});
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_LOAD_OFFSET, LOAD_OFFSET_I8, LOAD_OFFSET_I16,
@@ -804,199 +722,28 @@ struct STORE_OFFSET_I8
     : Sequence<STORE_OFFSET_I8,
                I<OPCODE_STORE_OFFSET, VoidOp, I64Op, I64Op, I8Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-    if (i.src3.is_constant) {
-      e.mov(e.w17, static_cast<uint64_t>(i.src3.constant() & 0xFF));
-      e.strb(e.w17, ptr(e.GetMembaseReg(), e.x0));
-    } else {
-      e.strb(i.src3, ptr(e.GetMembaseReg(), e.x0));
-    }
-    if (IsTracingData()) {
-      AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-      e.ldrb(e.w2, ptr(e.GetMembaseReg(), e.x0));
-      e.mov(e.w1, e.w0);
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreI8));
-    }
+    EmitStoreI8(e, {i.src1, &i.src2}, i.src3);
   }
 };
 struct STORE_OFFSET_I16
     : Sequence<STORE_OFFSET_I16,
                I<OPCODE_STORE_OFFSET, VoidOp, I64Op, I64Op, I16Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-      if (i.src3.is_constant) {
-        uint16_t val = xe::byte_swap(static_cast<uint16_t>(i.src3.constant()));
-        e.mov(e.w17, static_cast<uint64_t>(val));
-      } else {
-        e.rev16(e.w17, i.src3);
-      }
-      e.strh(e.w17, ptr(e.GetMembaseReg(), e.x0));
-    } else {
-      if (i.src3.is_constant) {
-        e.mov(e.w17, static_cast<uint64_t>(i.src3.constant() & 0xFFFF));
-        e.strh(e.w17, ptr(e.GetMembaseReg(), e.x0));
-      } else {
-        e.strh(i.src3, ptr(e.GetMembaseReg(), e.x0));
-      }
-    }
-    if (IsTracingData()) {
-      AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-      e.ldrh(e.w2, ptr(e.GetMembaseReg(), e.x0));
-      e.mov(e.w1, e.w0);
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreI16));
-    }
+    EmitStoreI16(e, i.instr, {i.src1, &i.src2}, i.src3);
   }
 };
 struct STORE_OFFSET_I32
     : Sequence<STORE_OFFSET_I32,
                I<OPCODE_STORE_OFFSET, VoidOp, I64Op, I64Op, I32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    if (IsPossibleMMIOInstruction(e, i.instr)) {
-      void* mmio_fn = (void*)&MMIOAwareStore<uint32_t, false>;
-      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-        mmio_fn = (void*)&MMIOAwareStore<uint32_t, true>;
-      }
-      if (i.src1.is_constant) {
-        e.mov(e.w1,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
-      } else {
-        e.mov(e.w1, WReg(i.src1.reg().getIdx()));
-      }
-      if (i.src2.is_constant) {
-        e.mov(e.w17,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src2.constant())));
-      } else {
-        e.mov(e.w17, WReg(i.src2.reg().getIdx()));
-      }
-      e.add(e.w1, e.w1, e.w17);
-      if (i.src3.is_constant) {
-        e.mov(e.w2,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src3.constant())));
-      } else {
-        e.mov(e.w2, i.src3);
-      }
-      e.CallNativeSafe(mmio_fn);
-      return;
-    }
-    if (cvars::emit_inline_mmio_checks && !IsTracingData()) {
-      // Compute raw guest address (src1 + src2) in w17 for range check.
-      if (i.src1.is_constant) {
-        e.mov(e.w17,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
-      } else {
-        e.mov(e.w17, WReg(i.src1.reg().getIdx()));
-      }
-      if (i.src2.is_constant) {
-        uint32_t offset = static_cast<uint32_t>(i.src2.constant());
-        if (offset != 0) {
-          e.mov(e.w0, static_cast<uint64_t>(offset));
-          e.add(e.w17, e.w17, e.w0);
-        }
-      } else {
-        e.add(e.w17, e.w17, WReg(i.src2.reg().getIdx()));
-      }
-      auto& normal_access = e.NewCachedLabel();
-      auto& done = e.NewCachedLabel();
-      e.mov(e.w0, 0x7FC00000u);
-      e.cmp(e.w17, e.w0);
-      e.b(LO, normal_access);
-      e.mov(e.w0, 0x7FFFFFFFu);
-      e.cmp(e.w17, e.w0);
-      e.b(HI, normal_access);
-      // MMIO path — copy value to w2 before w1 in case src3 is in w1
-      void* mmio_fn = (void*)&MMIOAwareStore<uint32_t, false>;
-      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-        mmio_fn = (void*)&MMIOAwareStore<uint32_t, true>;
-      }
-      if (i.src3.is_constant) {
-        e.mov(e.w2,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src3.constant())));
-      } else {
-        e.mov(e.w2, i.src3);
-      }
-      e.mov(e.w1, e.w17);
-      e.CallNativeSafe(mmio_fn);
-      e.b(done);
-      e.L(normal_access);
-      {
-        AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-        if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-          if (i.src3.is_constant) {
-            uint32_t val =
-                xe::byte_swap(static_cast<uint32_t>(i.src3.constant()));
-            e.mov(e.w17, static_cast<uint64_t>(val));
-          } else {
-            e.rev(e.w17, i.src3);
-          }
-          e.str(e.w17, ptr(e.GetMembaseReg(), e.x0));
-        } else {
-          if (i.src3.is_constant) {
-            e.mov(e.w17, static_cast<uint64_t>(
-                             static_cast<uint32_t>(i.src3.constant())));
-            e.str(e.w17, ptr(e.GetMembaseReg(), e.x0));
-          } else {
-            e.str(i.src3, ptr(e.GetMembaseReg(), e.x0));
-          }
-        }
-      }
-      e.L(done);
-    } else {
-      AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-        if (i.src3.is_constant) {
-          uint32_t val =
-              xe::byte_swap(static_cast<uint32_t>(i.src3.constant()));
-          e.mov(e.w17, static_cast<uint64_t>(val));
-        } else {
-          e.rev(e.w17, i.src3);
-        }
-        e.str(e.w17, ptr(e.GetMembaseReg(), e.x0));
-      } else {
-        if (i.src3.is_constant) {
-          e.mov(e.w17, static_cast<uint64_t>(
-                           static_cast<uint32_t>(i.src3.constant())));
-          e.str(e.w17, ptr(e.GetMembaseReg(), e.x0));
-        } else {
-          e.str(i.src3, ptr(e.GetMembaseReg(), e.x0));
-        }
-      }
-      if (IsTracingData()) {
-        AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-        e.ldr(e.w2, ptr(e.GetMembaseReg(), e.x0));
-        e.mov(e.w1, e.w0);
-        e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreI32));
-      }
-    }
+    EmitStoreI32(e, i.instr, {i.src1, &i.src2}, i.src3);
   }
 };
 struct STORE_OFFSET_I64
     : Sequence<STORE_OFFSET_I64,
                I<OPCODE_STORE_OFFSET, VoidOp, I64Op, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
-      if (i.src3.is_constant) {
-        uint64_t val = xe::byte_swap(static_cast<uint64_t>(i.src3.constant()));
-        e.mov(e.x17, val);
-      } else {
-        e.rev(e.x17, i.src3);
-      }
-      e.str(e.x17, ptr(e.GetMembaseReg(), e.x0));
-    } else {
-      if (i.src3.is_constant) {
-        e.mov(e.x17, static_cast<uint64_t>(i.src3.constant()));
-        e.str(e.x17, ptr(e.GetMembaseReg(), e.x0));
-      } else {
-        e.str(i.src3, ptr(e.GetMembaseReg(), e.x0));
-      }
-    }
-    if (IsTracingData()) {
-      AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
-      e.ldr(e.x2, ptr(e.GetMembaseReg(), e.x0));
-      e.mov(e.w1, e.w0);
-      e.CallNative(reinterpret_cast<void*>(TraceMemoryStoreI64));
-    }
+    EmitStoreI64(e, i.instr, {i.src1, &i.src2}, i.src3);
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_STORE_OFFSET, STORE_OFFSET_I8, STORE_OFFSET_I16,

--- a/src/xenia/cpu/backend/a64/a64_seq_util.h
+++ b/src/xenia/cpu/backend/a64/a64_seq_util.h
@@ -298,14 +298,28 @@ inline int SrcVReg(A64Emitter& e, const T& op, int scratch_idx) {
   return op.reg().getIdx();
 }
 
+inline bool NeedsPhysicalRemap() {
+  return xe::memory::allocation_granularity() > 0x1000;
+}
+
+inline void ApplyPhysicalRemapW0(A64Emitter& e) {
+  using namespace Xbyak_aarch64;
+  Xbyak_aarch64::Label skip;
+  e.lsr(e.w17, e.w0, 29);
+  e.cmp(e.w17, 7);
+  // skip is bound one instruction later, so b_near is in range.
+  e.b_near(NE, skip);
+  e.add(e.w0, e.w0, 1, 12);  // + 0x1000 via LSL #12
+  e.L(skip);
+}
+
 // Compute a guest memory address, returning the XReg for [x21, xN] addressing.
 // For constants, loads the address into x0 (scratch).
 inline XReg ComputeMemoryAddress(A64Emitter& e, const I64Op& guest) {
   using namespace Xbyak_aarch64;
   if (guest.is_constant) {
     uint32_t address = static_cast<uint32_t>(guest.constant());
-    if (address >= 0xE0000000 &&
-        xe::memory::allocation_granularity() > 0x1000) {
+    if (address >= 0xE0000000 && NeedsPhysicalRemap()) {
       address += 0x1000;
     }
     e.mov(e.x0, static_cast<uint64_t>(address));
@@ -315,24 +329,55 @@ inline XReg ComputeMemoryAddress(A64Emitter& e, const I64Op& guest) {
     // Guest addresses are always 32-bit. Clear any stale upper bits before
     // applying the host membase so guest pointers can't escape above 4 GB.
     e.mov(e.w0, WReg(src.getIdx()));
-    if (xe::memory::allocation_granularity() > 0x1000) {
-      // Branch-free: w17 = w0 + 0x1000, kept only when w0 >= 0xE0000000.
-      e.mov(e.w17, 0xE0000000u);
-      e.cmp(e.w0, e.w17);
-      e.add(e.w17, e.w0, 1, 12);  // w17 = w0 + 0x1000 via LSL #12
-      e.csel(e.w0, e.w0, e.w17, LO);
+    if (NeedsPhysicalRemap()) {
+      ApplyPhysicalRemapW0(e);
     }
     return e.x0;
   }
 }
 
+inline bool GuestMemDirectIndex(const I64Op& guest, int* out_w_idx) {
+  if (guest.is_constant || NeedsPhysicalRemap()) {
+    return false;
+  }
+  *out_w_idx = guest.reg().getIdx();
+  return true;
+}
+
+// The fallback address lives in x0; emit_access must not clobber it first.
+template <typename Fn>
+inline void EmitGuestMemAccess(A64Emitter& e, const I64Op& guest,
+                               Fn&& emit_access) {
+  int w_idx;
+  if (GuestMemDirectIndex(guest, &w_idx)) {
+    emit_access(ptr(e.GetMembaseReg(), WReg(w_idx), Xbyak_aarch64::UXTW));
+  } else {
+    emit_access(ptr(e.GetMembaseReg(), ComputeMemoryAddress(e, guest)));
+  }
+}
+
+// The remap is decided on the effective address, not the base, as on x64.
 template <typename OffsetOp>
-inline XReg AddGuestMemoryOffset(A64Emitter& e, const XReg& base,
-                                 const OffsetOp& offset) {
+inline XReg ComputeMemoryAddressOffset(A64Emitter& e, const I64Op& guest,
+                                       const OffsetOp& offset) {
+  using namespace Xbyak_aarch64;
+  if (guest.is_constant && offset.is_constant) {
+    uint32_t address = static_cast<uint32_t>(guest.constant()) +
+                       static_cast<uint32_t>(offset.constant());
+    if (address >= 0xE0000000 && NeedsPhysicalRemap()) {
+      address += 0x1000;
+    }
+    e.mov(e.x0, static_cast<uint64_t>(address));
+    return e.x0;
+  }
+  if (guest.is_constant) {
+    e.mov(e.w0, static_cast<uint64_t>(static_cast<uint32_t>(guest.constant())));
+  } else {
+    e.mov(e.w0, WReg(guest.reg().getIdx()));
+  }
   // Guest address arithmetic wraps at 32 bits before the host membase is
   // applied. Keep the add in W registers so stale high bits can't escape into
   // the final host pointer.
-  e.mov(e.w0, WReg(base.getIdx()));
   if (offset.is_constant) {
     const uint32_t imm = static_cast<uint32_t>(offset.constant());
     const uint32_t neg = 0u - imm;
@@ -354,7 +399,24 @@ inline XReg AddGuestMemoryOffset(A64Emitter& e, const XReg& base,
   } else {
     e.add(e.w0, e.w0, WReg(offset.reg().getIdx()));
   }
+  if (NeedsPhysicalRemap()) {
+    ApplyPhysicalRemapW0(e);
+  }
   return e.x0;
+}
+
+// Guest addresses wrap at 32 bits: a nonzero displacement is added in W first.
+template <typename OffsetOp, typename Fn>
+inline void EmitGuestMemAccessOffset(A64Emitter& e, const I64Op& guest,
+                                     const OffsetOp& offset, Fn&& emit_access) {
+  int w_idx;
+  if (offset.is_constant && offset.constant() == 0 &&
+      GuestMemDirectIndex(guest, &w_idx)) {
+    emit_access(ptr(e.GetMembaseReg(), WReg(w_idx), Xbyak_aarch64::UXTW));
+  } else {
+    emit_access(
+        ptr(e.GetMembaseReg(), ComputeMemoryAddressOffset(e, guest, offset)));
+  }
 }
 
 // Flush denormal float32 lanes to zero in a NEON register (in-place).

--- a/src/xenia/cpu/backend/a64/a64_seq_vector.cc
+++ b/src/xenia/cpu/backend/a64/a64_seq_vector.cc
@@ -1964,13 +1964,14 @@ static void EmitPartialVectorStore(A64Emitter& e,
   // Unqualified Label here is hir::Label.
   Xbyak_aarch64::Label from8, from4, from2, from1, done;
 
+  // Every label below is bound within this helper, so the near forms are safe.
   e.cmp(count, 8);
-  e.b(Xbyak_aarch64::HS, from8);
+  e.b_near(Xbyak_aarch64::HS, from8);
   e.cmp(count, 4);
-  e.b(Xbyak_aarch64::HS, from4);
+  e.b_near(Xbyak_aarch64::HS, from4);
   e.cmp(count, 2);
-  e.b(Xbyak_aarch64::HS, from2);
-  e.cbnz(count, from1);
+  e.b_near(Xbyak_aarch64::HS, from2);
+  e.cbnz_near(count, from1);
   e.b(done);
 
   e.L(from8);

--- a/src/xenia/cpu/backend/a64/a64_sequences.cc
+++ b/src/xenia/cpu/backend/a64/a64_sequences.cc
@@ -879,6 +879,10 @@ struct ZERO_EXTEND_I64_I32
     : Sequence<ZERO_EXTEND_I64_I32, I<OPCODE_ZERO_EXTEND, I64Op, I32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
     // mov wD, wS implicitly zero-extends to 64 bits on ARM64.
+    if (!i.src1.is_constant && i.dest.reg().getIdx() == i.src1.reg().getIdx()) {
+      // I32 values only come from W forms, so the upper half is already zero.
+      return;
+    }
     auto w_dest = WReg(i.dest.reg().getIdx());
     e.mov(w_dest, i.src1);
   }


### PR DESCRIPTION
On hosts whose allocation granularity exceeds 4 KiB the 0xE0000000 view
cannot be mapped at its true offset (it aliases the 0xC0000000 view
4 KiB further in, closer than one host page), so the CPU side adds
0x1000 to guest addresses at or above 0xE0000000. LOAD_OFFSET and
STORE_OFFSET applied that remap to the base register before adding the
displacement, so a base just below the boundary whose displacement
carried it above was not remapped, and a base above it with a negative
displacement was remapped when it should not have been: the same guest
address resolved two different ways depending on how constant folding
had split it. ComputeMemoryAddressOffset now forms the 32-bit effective
address first (base plus displacement in W registers, so the wrap at
bit 31 is preserved) and decides the remap on that, which is what the
x64 backend's ComputeMemoryAddressOffset does.

Addressing shortcuts, all on the same helpers:
- Register guest addresses on hosts without the remap index guest
  memory directly as [membase, Wsrc, UXTW]; the addressing mode's
  zero-extension replaces the mov that ComputeMemoryAddress emitted.
  The offset forms take the direct form only for a zero constant
  displacement, since a nonzero one must be added in W first.
- The remap itself is a predicted-not-taken branch (lsr, cmp, b_near,
  add) rather than mov/cmp/add/csel, keeping it off the load's
  dependency chain. TryInlinePPCGprLrSaveRestore in a64_emitter.cc still
  carries its own csel form of the remap; routing it through
  ApplyPhysicalRemapW0 is left for a follow-up.
- The inline MMIO range test is one shift and a 9-bit compare
  (EmitMmioRangeTest: lsr, cmp, b_near) instead of two materialised
  bounds and two compares.
- STORE_V128 resolves its source into a Q register before forming the
  address. ZERO_EXTEND_I64_I32 with dest == src emits nothing: I32
  values are only produced through W forms, whose upper half is
  already zero (TRUNCATE_I32_I64 is not elidable for the mirror
  reason).
- EmitPartialVectorStore uses the near branch forms; every label is
  bound within the helper. This is an encoding-only change and is not
  covered by the corpus.

Evidence: emitted size (corpus replay -356,444 host bytes from the
zero-extend elision) and the PPC corpus gate 169,044/169,044 passing.
The remap branch and the MMIO test change are unmeasured at runtime.