### PR TITLE
[CPU] Seed dead context-store elimination from successor kill sets

### DIFF
--- a/src/xenia/cpu/compiler/passes/context_promotion_pass.cc
+++ b/src/xenia/cpu/compiler/passes/context_promotion_pass.cc
@@ -68,6 +68,9 @@ bool ContextPromotionPass::Initialize(Compiler* compiler) {
   context_value_size_.resize(sizeof(ppc::PPCContext));
   context_value_base_.resize(sizeof(ppc::PPCContext));
   context_validity_.resize(static_cast<uint32_t>(sizeof(ppc::PPCContext)));
+  context_kill_.resize(static_cast<uint32_t>(sizeof(ppc::PPCContext)));
+  context_kill_scratch_.resize(static_cast<uint32_t>(sizeof(ppc::PPCContext)));
+  context_kill_read_.resize(static_cast<uint32_t>(sizeof(ppc::PPCContext)));
 
   return true;
 }
@@ -215,11 +218,63 @@ void ContextPromotionPass::PromoteBlock(Block* block) {
   }
 }
 
+void ContextPromotionPass::ComputeKillSet(Block* block, llvm::BitVector& kill) {
+  kill.reset();
+  auto& read = context_kill_read_;
+  read.reset();
+  Instr* i = block->instr_head;
+  while (i) {
+    if (i->opcode->flags & OPCODE_FLAG_VOLATILE) {
+      return;
+    }
+    if (i->opcode == &OPCODE_LOAD_CONTEXT_info) {
+      const uint32_t offset = static_cast<uint32_t>(i->src1.offset);
+      const uint32_t size = static_cast<uint32_t>(GetTypeSize(i->dest->type));
+      for (uint32_t b = offset; b < offset + size; ++b) {
+        if (!kill.test(b)) {
+          read.set(b);
+        }
+      }
+    } else if (i->opcode == &OPCODE_STORE_CONTEXT_info) {
+      const uint32_t offset = static_cast<uint32_t>(i->src1.offset);
+      const uint32_t size =
+          static_cast<uint32_t>(GetTypeSize(i->src2.value->type));
+      for (uint32_t b = offset; b < offset + size; ++b) {
+        if (!read.test(b)) {
+          kill.set(b);
+        }
+      }
+    }
+    i = i->next;
+  }
+}
+
+void ContextPromotionPass::ComputeOutgoingKillSet(Block* block,
+                                                  llvm::BitVector& out) {
+  out.reset();
+  auto edge = block->outgoing_edge_head;
+  if (!edge) {
+    return;
+  }
+  bool first = true;
+  while (edge) {
+    ComputeKillSet(edge->dest, context_kill_scratch_);
+    if (first) {
+      out = context_kill_scratch_;
+      first = false;
+    } else {
+      out &= context_kill_scratch_;
+    }
+    edge = edge->outgoing_next;
+  }
+}
+
 void ContextPromotionPass::RemoveDeadStoresBlock(Block* block) {
   // In this walk a validity bit means "this byte is fully overwritten by a
   // later store in this block, with no barrier or load in between".
   auto& validity = context_validity_;
-  validity.reset();
+  ComputeOutgoingKillSet(block, context_kill_);
+  validity = context_kill_;
   const bool promote_vec128 =
       cvars::context_promote_vec128 && !cvars::disable_context_promotion;
 
@@ -228,9 +283,12 @@ void ContextPromotionPass::RemoveDeadStoresBlock(Block* block) {
   Instr* i = block->instr_tail;
   while (i) {
     Instr* prev = i->prev;
-    if (i->opcode->flags & (OPCODE_FLAG_VOLATILE | OPCODE_FLAG_BRANCH)) {
+    if (i->opcode->flags & OPCODE_FLAG_VOLATILE) {
       // Volatile instruction - requires all context values be flushed.
       validity.reset();
+    } else if (i->opcode->flags & OPCODE_FLAG_BRANCH) {
+      // Tested after VOLATILE so a call or a return still flushes.
+      validity = context_kill_;
     } else if (i->opcode == &OPCODE_LOAD_CONTEXT_info) {
       // A load that survived PromoteBlock is a live use of these bytes:
       // earlier stores overlapping it must be kept. (PromoteBlock folds

--- a/src/xenia/cpu/compiler/passes/context_promotion_pass.h
+++ b/src/xenia/cpu/compiler/passes/context_promotion_pass.h
@@ -52,6 +52,11 @@ class ContextPromotionPass : public CompilerPass {
   void TrackValue(uint32_t offset, uint32_t size, hir::Value* value);
   void InvalidateTrackedRange(uint32_t offset, uint32_t size);
 
+  // Bytes overwritten before being read; stops at the first volatile instr.
+  void ComputeKillSet(hir::Block* block, llvm::BitVector& kill);
+  // Intersection of ComputeKillSet over the successors; empty without any.
+  void ComputeOutgoingKillSet(hir::Block* block, llvm::BitVector& out);
+
  private:
   // Indexed by base byte offset into the context: the tracked SSA value
   // whose range starts there, and that range's size in bytes.
@@ -62,6 +67,9 @@ class ContextPromotionPass : public CompilerPass {
   std::vector<uint32_t> context_value_base_;
   // Byte-granular: bit b is set iff some tracked value's range covers b.
   llvm::BitVector context_validity_;
+  llvm::BitVector context_kill_;
+  llvm::BitVector context_kill_scratch_;
+  llvm::BitVector context_kill_read_;
 };
 
 }  // namespace passes


### PR DESCRIPTION
RemoveDeadStoresBlock walks a block backwards and drops a store_context
whose bytes a later store in the same block overwrites with no load or
volatile instruction in between. It started every block with an empty
set and reset the set at any BRANCH, and a block's last instruction is
its branch, so the set was always empty by the time the walk reached a
real instruction: no store before a block's terminator was ever
removed, which is most of them.

The walk is now seeded with the intersection, over every successor, of
the bytes that successor stores before it reads them (ComputeKillSet,
a forward scan that stops at the first volatile instruction, since a
call or a preempt check can read the whole context). A store is dead
when every block control can reach next overwrites its bytes before
reading them, whatever happens afterwards. A block with no successors
seeds empty: the function returns from it and the caller reads the
context. Inside the walk a BRANCH restores that seed instead of
clearing the set; VOLATILE is tested first, so a call or a return,
which carries both flags, still flushes everything.

VEC128 stores count towards the kill set even when
context_promote_vec128 is off: whether the pass may delete a vector
store is a separate question from whether that store overwrites the
bytes, and it does.

This deliberately does not forward values across blocks.
DataFlowAnalysisPass forces any value used outside its defining block
through a local slot and the register allocator keeps registers within
a block, so forwarding a context value across an edge would trade a
context store/load pair for a stack store/load pair while the context
store usually still has to happen. Deleting stores needs no cross-block
value and is sound on its own.

Known gap, left as a follow-up: branch_true and branch_false carry
OPCODE_FLAG_VOLATILE and the walk tests VOLATILE before BRANCH, so a
block that ends in a conditional branch still flushes at that branch
and only the stores after it see the seed. Blocks ending in a plain
branch get the full effect.

Evidence: -26,376 host bytes (-0.09%) of laid-down code on a captured
menu corpus; 169,044/169,044 PPC corpus cases pass. The size change is
small, which says most context stores are live across their block
boundary; the change is kept because it is exact and free at runtime.