### PR TITLE
[CPU] Number every block and instruction before allocating registers

### DIFF
--- a/src/xenia/cpu/compiler/passes/register_allocation_pass.cc
+++ b/src/xenia/cpu/compiler/passes/register_allocation_pass.cc
@@ -76,26 +76,24 @@ bool RegisterAllocationPass::Run(HIRBuilder* builder) {
   // Really, it'd just be nice to have someone who knew what they
   // were doing lower SSA and do this right.
 
-  uint16_t block_ordinal = 0;
-  uint32_t instr_ordinal = 0;
+  // Uses sort by ordinal, so every block is numbered before any allocation.
+  {
+    uint16_t pre_block_ordinal = 0;
+    uint32_t pre_instr_ordinal = 0;
+    for (auto b = builder->first_block(); b; b = b->next) {
+      b->ordinal = pre_block_ordinal++;
+      for (auto i = b->instr_head; i; i = i->next) {
+        i->ordinal = pre_instr_ordinal++;
+      }
+    }
+  }
+
   auto block = builder->first_block();
   while (block) {
-    // Sequential block ordinals.
-    block->ordinal = block_ordinal++;
-
     // Reset all state.
     PrepareBlockState();
 
-    // Renumber all instructions in the block. This is required so that
-    // we can sort the usage pointers below.
     auto instr = block->instr_head;
-    while (instr) {
-      // Sequential global instruction ordinals.
-      instr->ordinal = instr_ordinal++;
-      instr = instr->next;
-    }
-
-    instr = block->instr_head;
     while (instr) {
       const auto info = instr->opcode;
       uint32_t signature = info->signature;


### PR DESCRIPTION
RegisterAllocationPass numbered blocks and instructions inside the same
walk that allocates them. Instructions are born with ordinal UINT32_MAX
(hir_builder.cc), a value's usage list is sorted by that ordinal
(CompareValueUse), and AdvanceUses retires a register when a use is the
last one in that order. A value whose uses reach a later block was
therefore sorted while that block was still unnumbered: those uses all
compared equal at UINT32_MAX while the ordinal subtraction overflowed
against the numbered ones, so the tail of the list came out in
arbitrary order and a register could be retired with a real use still
ahead of it.

The pass now numbers every block and instruction in the function in a
pre-pass and only then allocates.

Nothing in the tree creates a value that outlives its block today:
DataFlowAnalysisPass forces every cross-block use through a local slot,
so the misordering is latent and this change alters no generated code.
It is fixed now rather than left for the next pass that produces a
cross-block value.

Evidence: the 169,044-case PPC corpus passes with the change; since the
condition is unreachable today, no behavioural difference was expected
or observed.