### PR TITLE
[Kernel] Park host-thread guest threads that keep delaying for zero time

### DIFF
--- a/src/xenia/kernel/xthread.cc
+++ b/src/xenia/kernel/xthread.cc
@@ -29,6 +29,14 @@
 #include "xenia/kernel/user_module.h"
 #include "xenia/kernel/xboxkrnl/xboxkrnl_threading.h"
 
+DEFINE_int32(zero_delay_spin_limit, 16,
+             "Consecutive zero-timeout guest delays before the thread is "
+             "parked instead of yielding; 0 disables. Host-thread mode only.",
+             "Kernel");
+DEFINE_uint32(zero_delay_park_ns, 60000,
+              "Park length, in nanoseconds, once zero_delay_spin_limit trips.",
+              "Kernel");
+
 DEFINE_bool(ignore_thread_priorities, false,
             "Ignores game-specified thread priorities.", "Kernel");
 UPDATE_from_bool(ignore_thread_priorities, 2026, 4, 9, 12, true);
@@ -1268,7 +1276,24 @@ X_STATUS XThread::Delay(uint32_t processor_mode, uint32_t alertable,
     }
   } else {
     if (timeout_ms == 0) {
-      if (priority_ <= xe::threading::ThreadPriority::kBelowNormal) {
+      // Raw host ticks: QueryHostUptimeMillis() re-reads mach_timebase_info().
+      const int32_t spin_limit = cvars::zero_delay_spin_limit;
+      bool park = false;
+      if (spin_limit > 0) {
+        static const uint64_t kResetGapTicks =
+            Clock::host_tick_frequency_raw() / 1000;
+        const uint64_t now = Clock::host_tick_count_raw();
+        if (zero_delay_last_tick_ == 0 ||
+            now - zero_delay_last_tick_ > kResetGapTicks) {
+          zero_delay_spins_ = 0;
+        }
+        zero_delay_last_tick_ = now;
+        park = ++zero_delay_spins_ >= static_cast<uint32_t>(spin_limit);
+      }
+      if (park) {
+        zero_delay_spins_ = 0;
+        xe::threading::NanoSleep(int64_t(cvars::zero_delay_park_ns));
+      } else if (priority_ <= xe::threading::ThreadPriority::kBelowNormal) {
         xe::threading::NanoSleep(100);
       } else {
         xe::threading::MaybeYield();

--- a/src/xenia/kernel/xthread.h
+++ b/src/xenia/kernel/xthread.h
@@ -715,6 +715,9 @@ class XThread : public XObject, public cpu::Thread {
   SchedulerLinks scheduler_links_;
   // Set by the first ReclaimExited so both terminal paths reclaim once.
   std::atomic<bool> self_reference_dropped_{false};
+  // Owning thread only; no atomics.
+  uint32_t zero_delay_spins_ = 0;
+  uint64_t zero_delay_last_tick_ = 0;
   // Owned by XObject::Enter/LeaveCooperativeWait.
   std::atomic<XObject*> cooperative_wait_object_{nullptr};
   // Signaled when a fiber-backed thread exits, so waits on the thread object


### PR DESCRIPTION
Host-thread mode only (--guest_scheduler=false): the fiber path in
XThread::Delay already yields the fiber and is untouched. In host-thread
mode a zero-timeout delay yields the host thread, which returns almost
immediately whenever a core is spare, so a guest Sleep(0) poll loop
runs at host syscall rate and holds a core for the whole wait.

Count consecutive zero-timeout delays per thread, restarting the run
when more than 1ms passes between two of them, and once the count
reaches --zero_delay_spin_limit (default 16) park the thread for
--zero_delay_park_ns (default 60000) instead of yielding. 0 disables
the park and keeps the plain yield.

This is a guest-observable timing change: a Sleep(0) poll loop that
trips the limit now waits about 60us per iteration instead of a yield.
Networked play was not exercised.

Measured on Halo Reach, --guest_scheduler=false: -51.56% process CPU
at the menu (160.62 -> 77.81, 3/3 pairs) and -39.36% in campaign; null
on Halo 3 and GTA IV. Not measured: the fiber configuration
(--guest_scheduler=true, the default), which never reaches this code,
and x64.