### PR TITLE
[Base] Block the timer queue thread on POSIX instead of spinning

### DIFF
--- a/src/xenia/base/threading_timer_queue.cc
+++ b/src/xenia/base/threading_timer_queue.cc
@@ -16,6 +16,7 @@
 #include "third_party/disruptorplus/include/disruptorplus/spin_wait.hpp"
 #include "third_party/disruptorplus/include/disruptorplus/spin_wait_strategy.hpp"
 #include "xenia/base/assert.h"
+#include "xenia/base/platform.h"
 #include "xenia/base/threading.h"
 #include "xenia/base/threading_timer_queue.h"
 
@@ -42,7 +43,13 @@ using WaitItem = TimerQueueWaitItem;
     edit2: (30.12.2024) After uplifting version of MSVC compiler Xenia cannot be
    correctly initialized if you're using proton.
 */
+// Windows keeps spinning: blocking waits deadlocked initialisation under
+// Proton (c3301d928).
+#if XE_PLATFORM_WIN32
 using WaitStrat = dp::spin_wait_strategy;
+#else
+using WaitStrat = dp::blocking_wait_strategy;
+#endif
 
 class TimerQueue {
  public:
@@ -87,7 +94,7 @@ class TimerQueue {
         // Consume new wait items and add them to sorted wait queue
         dp::sequence_t available = claim_strategy_.wait_until_published(
             next_sequence, next_sequence - 1,
-            wait_queue_.empty() ? clock::time_point::max()
+            wait_queue_.empty() ? clock::now() + kIdleWait
                                 : wait_queue_.front()->due_);
 
         // Check for timeout
@@ -161,6 +168,8 @@ class TimerQueue {
   const std::thread& dispatch_thread() const { return dispatch_thread_; }
 
  private:
+  static constexpr clock::duration kIdleWait = std::chrono::seconds(60);
+
   // This ring buffer will be used to introduce timers queued by the public API
   static constexpr size_t kWaitCount = 512;
   dp::ring_buffer<std::shared_ptr<WaitItem>> buffer_;


### PR DESCRIPTION
TimerQueue's dispatch thread waits for new timers with disruptorplus's
spin_wait_strategy, which yields in a loop for the whole wait. On POSIX
switch to blocking_wait_strategy, which blocks on the ring's condition
variable and is woken by signal_all_when_blocking() from both publish
paths (multi_threaded_claim_strategy::publish and
sequence_barrier::publish), so a queued timer still wakes the thread
immediately. The idle wait is bounded to 60s rather than
time_point::max() so an idle queue never depends on a library's
handling of an unbounded deadline. Windows keeps the spin strategy.

This has been tried twice. 495b1f8bc returned to the spin because the
vendored blocking_wait_strategy passes wait_for's arguments in the
wrong order and the build broke; that member template is still wrong
and is not fixed here, but the queue waits on a time_point, which
instantiates only the time_point overload. c3301d928 restored the spin
because a newer MSVC build deadlocked during initialisation under
Proton; that is Windows under Wine, and Windows is untouched by this
change (#if XE_PLATFORM_WIN32).

Known limitation: on macOS libc++ has no _LIBCPP_HAS_COND_CLOCKWAIT, so
the timed wait is anchored to the wall clock and a clock step can delay
one wait by the size of the step. TimerThreadMain re-reads steady_clock
each iteration and fires everything due, so the queue catches up on the
next wake rather than drifting. Whether a timer that fires late is ever
worse in practice than the spin it replaces was not verified.

Measured on the Halo 3 menu, --guest_scheduler=false, three
interleaved pairs: -2.74% process CPU (86.08 -> 83.57), noise floor
0.49%; TimerQueue samples 887 -> 46; 29.86 vs 29.85 fps. Not measured:
the fiber configuration (--guest_scheduler=true, the default), Windows,
and x64.