### PR TITLE
[GPU/Metal] Upload only the float constants the shader declares

### DIFF
--- a/src/xenia/gpu/metal/metal_command_processor.cc
+++ b/src/xenia/gpu/metal/metal_command_processor.cc
@@ -4507,10 +4507,19 @@ bool MetalCommandProcessor::IssueDrawDxil(
   MetalDxilBinder::Constants constants;
   constants.system = {&spirv_system_constants_,
                       uint32_t(sizeof(spirv_system_constants_))};
+  // The uniform block is declared as float_count vec4s (256 with
+  // float_dynamic_addressing), so nothing past that is addressable.
+  auto declared_float_bytes = [](const Shader* shader) -> uint32_t {
+    if (!shader) {
+      return 0;
+    }
+    return std::min(uint32_t(shader->constant_register_map().float_count) * 16u,
+                    uint32_t(kCbvSizeBytes));
+  };
   constants.float_vertex = {msl_cached_float_constants_vertex_.data(),
-                            uint32_t(kCbvSizeBytes)};
+                            declared_float_bytes(dxil_vertex_shader)};
   constants.float_pixel = {msl_cached_float_constants_pixel_.data(),
-                           uint32_t(kCbvSizeBytes)};
+                           declared_float_bytes(dxil_pixel_shader)};
   constants.bool_loop = {msl_cached_bool_loop_constants_.data(),
                          uint32_t(kBoolLoopConstantsSize)};
   constants.fetch = {msl_cached_fetch_constants_.data(),


### PR DESCRIPTION
MetalDxilBinder::Bind copies every constant block into a fresh
transient slice on every draw. Both float-constant blocks were passed
as the full kCbvSizeBytes (4 KiB each), so about 8 KiB of the ~9.8 KiB
copied per draw was zero fill.

IssueDrawDxil now sizes each float block as float_count * 16 bytes
from the shader's constant register map. rebuild_packed_float_constants
writes float_count vec4s tight-packed and zero-fills the remainder, and
the SPIR-V translator declares the uniform block as an array of exactly
float_count vec4s, so everything past that point is zeros the shader
has no way to address. float_count is either the tight-packed bit
count or exactly 256 when float_dynamic_addressing is set, which is the
full 4 KiB again, so the smaller size can never truncate something the
shader can reach. The std::min against kCbvSizeBytes is a guard on that
invariant, not something the binder relies on. The size only governs
the copy: the binder binds the argument buffer by buffer, offset and
index and passes no length.

Evidence, from a non-frame-capped in-game state (3 interleaved A/B
pairs, 100 s warm-up, 60 s windows, guest scheduler off):

  swaps/s        35.90 -> 45.91   +28.0%, 3/3 pairs agree
  CPU per swap   10.93 -> 8.93    -18.3%
  _platform_memmove share of on-core CPU   5.8% -> 1.7%

Before the change MetalDxilBinder::Bind was 32.6% of the GPU Commands
thread in that state, 87% of it inside the copy. The swaps/s counter is
a PM4 swap count rather than a present count and reads higher than the
Metal HUD; both arms share it, so the relative change holds but the
absolute rate is not fps. Total CPU rose 4.4% because the state is not
frame-capped and a faster emulator renders more frames; read the
throughput and per-swap figures, not total CPU.

Follow-up: the MSL (non-DXIL) draw path still copies kCbvSizeBytes for
both float blocks.