### PR TITLE
[A64] Release the core from guest wait loops

### DIFF
--- a/src/xenia/cpu/backend/a64/a64_backend.h
+++ b/src/xenia/cpu/backend/a64/a64_backend.h
@@ -122,6 +122,12 @@ struct A64BackendContext {
   unsigned int Ox1000;  // constant 0x1000
   // DEFAULT_VMX_FPCR regardless of NJM, for the ops that always flush
   unsigned int fpcr_vmx_daz;
+  unsigned int db16cyc_spins;
+  uint64_t db16cyc_last_tick;
+  unsigned int spin_wait_spins;
+  unsigned int spin_wait_site;
+  unsigned int spin_wait_armed;
+  uint64_t spin_wait_reset_tick;
 };
 
 // Default FPCR for FPU mode (round to nearest, no flush to zero).

--- a/src/xenia/cpu/backend/a64/a64_seq_memory.cc
+++ b/src/xenia/cpu/backend/a64/a64_seq_memory.cc
@@ -9,15 +9,19 @@
 
 #include "xenia/cpu/backend/a64/a64_sequences.h"
 
+#include <algorithm>
 #include "xenia/base/clock.h"
 #include "xenia/base/cvar.h"
+#include "xenia/base/logging.h"
 #include "xenia/base/memory.h"
+#include "xenia/base/threading.h"
 #include "xenia/cpu/backend/a64/a64_backend.h"
 #include "xenia/cpu/backend/a64/a64_emitter.h"
 #include "xenia/cpu/backend/a64/a64_op.h"
 #include "xenia/cpu/backend/a64/a64_seq_util.h"
 #include "xenia/cpu/backend/a64/a64_stack_layout.h"
 #include "xenia/cpu/backend/a64/a64_tracers.h"
+#include "xenia/cpu/cpu_flags.h"
 #include "xenia/cpu/hir/instr.h"
 #include "xenia/cpu/ppc/ppc_context.h"
 #include "xenia/cpu/processor.h"
@@ -58,9 +62,75 @@ static bool IsPossibleMMIOInstruction(A64Emitter& e, const hir::Instr* i) {
 // ============================================================================
 // OPCODE_DELAY_EXECUTION
 // ============================================================================
+static constexpr uint64_t kDb16cycSleepNs = 60000;
+static constexpr uint64_t kDb16cycGapNs = 1000;
+
+// CNTFRQ_EL0.
+static uint64_t SpinWaitTimerFreq() {
+  static const uint64_t freq = [] {
+    uint64_t f;
+    asm volatile("mrs %0, cntfrq_el0" : "=r"(f));
+    return f;
+  }();
+  return freq;
+}
+
+static void SpinWaitRelease(void* raw_context) {
+  if (backend::spin_wait_release_handler) {
+    backend::spin_wait_release_handler(raw_context, kDb16cycSleepNs);
+    return;
+  }
+  xe::threading::NanoSleep(int64_t(kDb16cycSleepNs));
+}
+
+static constexpr uint32_t kSpinWaitRetripIters = 64;
+
+// State is keyed to the loop header: the iteration counter is shared by every
+// tagged site on the thread.
+static void InjectedSpinWaitTrip(void* raw_context, uint64_t site) {
+  auto* context = reinterpret_cast<ppc::PPCContext*>(raw_context);
+  auto* bctx = static_cast<A64Backend*>(context->processor->backend())
+                   ->BackendContextForGuestContext(raw_context);
+  uint64_t now;
+  asm volatile("mrs %0, cntvct_el0" : "=r"(now));
+  const uint32_t site32 = uint32_t(site);
+  if (site32 != bctx->spin_wait_site) {
+    bctx->spin_wait_site = site32;
+    bctx->spin_wait_armed = 0;
+    bctx->spin_wait_spins = 0;
+    bctx->spin_wait_reset_tick = now;
+    return;
+  }
+  const uint64_t elapsed_ticks = now - bctx->spin_wait_reset_tick;
+  const uint64_t iters = bctx->spin_wait_armed ? kSpinWaitRetripIters
+                                               : cvars::spin_wait_yield_after;
+  const uint64_t budget_ticks = iters * uint64_t(cvars::spin_wait_max_iter_ns) *
+                                SpinWaitTimerFreq() / 1000000000ull;
+  if (elapsed_ticks <= budget_ticks) {
+    if (!bctx->spin_wait_armed) {
+      XELOGD("SpinWait: escalating guest loop {:08X}", site32);
+    }
+    SpinWaitRelease(raw_context);
+    const uint32_t threshold = cvars::spin_wait_yield_after;
+    bctx->spin_wait_armed = 1;
+    bctx->spin_wait_spins =
+        threshold > kSpinWaitRetripIters ? threshold - kSpinWaitRetripIters : 0;
+    asm volatile("mrs %0, cntvct_el0" : "=r"(now));
+    bctx->spin_wait_reset_tick = now;
+  } else {
+    bctx->spin_wait_armed = 0;
+    bctx->spin_wait_spins = 0;
+    bctx->spin_wait_reset_tick = now;
+  }
+}
+
 struct DELAY_EXECUTION
     : Sequence<DELAY_EXECUTION, I<OPCODE_DELAY_EXECUTION, VoidOp>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    if (i.instr->flags & hir::DELAY_EXECUTION_INJECTED) {
+      EmitInjectedSpinCheck(e, i);
+      return;
+    }
     // db16cyc throttles a guest spin loop. yield is the literal translation
     // but NOPs on Cortex-X/A7xx, so the sled cost nothing; isb is the usual
     // stand-in - a pipeline flush with no guest-observable effect. Coalesce
@@ -71,7 +141,66 @@ struct DELAY_EXECUTION
             kIsbSy) {
       return;
     }
+    const uint32_t yield_after = cvars::db16cyc_yield_after;
+    if (!yield_after) {
+      e.isb(Xbyak_aarch64::SY);
+      return;
+    }
+
+    const int32_t spins_offset =
+        static_cast<int32_t>(offsetof(A64BackendContext, db16cyc_spins));
+    const int32_t last_tick_offset =
+        static_cast<int32_t>(offsetof(A64BackendContext, db16cyc_last_tick));
+    const uint64_t gap_ticks = std::max<uint64_t>(
+        1, kDb16cycGapNs * SpinWaitTimerFreq() / 1000000000ull);
+    auto& not_consecutive = e.NewCachedLabel();
+    auto& do_release = e.NewCachedLabel();
+    auto& do_delay = e.NewCachedLabel();
+    // x16 = CNTVCT_EL0, x17 = ticks since the previous delay.
+    e.mrs(e.x16, 3, 3, 14, 0, 2);
+    e.ldr(e.x17, ptr(e.GetBackendCtxReg(), last_tick_offset));
+    e.str(e.x16, ptr(e.GetBackendCtxReg(), last_tick_offset));
+    e.sub(e.x17, e.x16, e.x17);
+    e.mov(e.x16, gap_ticks);
+    e.cmp(e.x17, e.x16);
+    e.b(HI, not_consecutive);
+    e.ldr(e.w16, ptr(e.GetBackendCtxReg(), spins_offset));
+    e.add(e.w16, e.w16, 1);
+    e.mov(e.w17, static_cast<uint64_t>(yield_after));
+    e.cmp(e.w16, e.w17);
+    e.b(HS, do_release);
+    e.str(e.w16, ptr(e.GetBackendCtxReg(), spins_offset));
+    e.b(do_delay);
+    e.L(not_consecutive);
+    e.mov(e.w16, 1);
+    e.str(e.w16, ptr(e.GetBackendCtxReg(), spins_offset));
+    e.b(do_delay);
+    e.L(do_release);
+    e.str(e.wzr, ptr(e.GetBackendCtxReg(), spins_offset));
+    e.CallNativeSafe(reinterpret_cast<void*>(SpinWaitRelease));
+    e.L(do_delay);
+    // Every path ends in the isb the coalescing test looks for.
     e.isb(Xbyak_aarch64::SY);
+  }
+
+  static void EmitInjectedSpinCheck(A64Emitter& e, const EmitArgType& i) {
+    const uint32_t threshold = cvars::spin_wait_yield_after;
+    if (!threshold) {
+      return;
+    }
+    const int32_t spins_offset =
+        static_cast<int32_t>(offsetof(A64BackendContext, spin_wait_spins));
+    auto& not_yet = e.NewCachedLabel();
+    e.ldr(e.w16, ptr(e.GetBackendCtxReg(), spins_offset));
+    e.add(e.w16, e.w16, 1);
+    e.str(e.w16, ptr(e.GetBackendCtxReg(), spins_offset));
+    e.mov(e.w17, static_cast<uint64_t>(threshold));
+    e.cmp(e.w16, e.w17);
+    e.b(LO, not_yet);
+    // x1 passes through the thunk as the helper's second argument.
+    e.mov(e.w1, static_cast<uint64_t>(uint32_t(i.instr->src1.offset)));
+    e.CallNativeSafe(reinterpret_cast<void*>(InjectedSpinWaitTrip));
+    e.L(not_yet);
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_DELAY_EXECUTION, DELAY_EXECUTION);

--- a/src/xenia/cpu/backend/backend.cc
+++ b/src/xenia/cpu/backend/backend.cc
@@ -31,6 +31,8 @@ void* Backend::AllocThreadData() { return nullptr; }
 void Backend::FreeThreadData(void* thread_data) {}
 
 void (*preempt_yield_handler)(void* raw_context) = nullptr;
+void (*spin_wait_release_handler)(void* raw_context,
+                                  uint64_t sleep_ns) = nullptr;
 
 uint32_t Backend::ReservedLoad32(ppc::PPCContext* context, uint32_t address) {
   return xe::byte_swap(*context->TranslateVirtual<uint32_t*>(address));

--- a/src/xenia/cpu/backend/backend.h
+++ b/src/xenia/cpu/backend/backend.h
@@ -206,6 +206,10 @@ struct GuestTrampolineGroup
 // context's preempt_requested flag.
 extern void (*preempt_yield_handler)(void* raw_context);
 
+// Registered by the cooperative scheduler, null otherwise; without it the
+// backend sleeps the host thread for |sleep_ns|.
+extern void (*spin_wait_release_handler)(void* raw_context, uint64_t sleep_ns);
+
 }  // namespace backend
 }  // namespace cpu
 }  // namespace xe

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -3617,6 +3617,10 @@ static void MaybeYieldForwarder(void* ctx) { xe::threading::MaybeYield(); }
 struct DELAY_EXECUTION
     : Sequence<DELAY_EXECUTION, I<OPCODE_DELAY_EXECUTION, VoidOp>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
+    if (i.instr->flags & hir::DELAY_EXECUTION_INJECTED) {
+      // SpinWaitInjectionPass tag; only the a64 backend counts these.
+      return;
+    }
     // todo: what if they dont have smt?
     if (cvars::delay_via_maybeyield) {
       e.CallNativeSafe((void*)MaybeYieldForwarder);

--- a/src/xenia/cpu/compiler/compiler_passes.h
+++ b/src/xenia/cpu/compiler/compiler_passes.h
@@ -23,6 +23,7 @@
 #include "xenia/cpu/compiler/passes/preempt_check_injection_pass.h"
 #include "xenia/cpu/compiler/passes/register_allocation_pass.h"
 #include "xenia/cpu/compiler/passes/simplification_pass.h"
+#include "xenia/cpu/compiler/passes/spin_wait_injection_pass.h"
 #include "xenia/cpu/compiler/passes/validation_pass.h"
 #include "xenia/cpu/compiler/passes/value_reduction_pass.h"
 

--- a/src/xenia/cpu/compiler/passes/back_edge_walk.h
+++ b/src/xenia/cpu/compiler/passes/back_edge_walk.h
@@ -1,0 +1,74 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_CPU_COMPILER_PASSES_BACK_EDGE_WALK_H_
+#define XENIA_CPU_COMPILER_PASSES_BACK_EDGE_WALK_H_
+
+#include <cstdint>
+#include <unordered_set>
+
+#include "xenia/cpu/hir/hir_builder.h"
+
+namespace xe {
+namespace cpu {
+namespace compiler {
+namespace passes {
+
+// Blocks are laid out in guest address order, so every intra-function cycle
+// branches to an already-seen block; fn(header, latch) is called for each.
+template <typename Fn>
+void ForEachBackEdge(hir::HIRBuilder* builder, Fn&& fn) {
+  std::unordered_set<hir::Block*> seen;
+  for (auto block = builder->first_block(); block != nullptr;
+       block = block->next) {
+    seen.insert(block);
+    for (auto instr = block->instr_head; instr != nullptr;
+         instr = instr->next) {
+      hir::Label* label = nullptr;
+      if (instr->opcode == &hir::OPCODE_BRANCH_info) {
+        label = instr->src1.label;
+      } else if (instr->opcode == &hir::OPCODE_BRANCH_TRUE_info ||
+                 instr->opcode == &hir::OPCODE_BRANCH_FALSE_info) {
+        label = instr->src2.label;
+      }
+      if (label && label->block && seen.count(label->block)) {
+        fn(label->block, block);
+      }
+    }
+  }
+}
+
+// A block holding only fake instructions falls through to the next.
+inline hir::Instr* FirstRealInstr(hir::Block* block) {
+  for (auto b = block; b != nullptr; b = b->next) {
+    auto first = b->instr_head;
+    for (; first && first->IsFake(); first = first->next) {
+    }
+    if (first) {
+      return first;
+    }
+  }
+  return nullptr;
+}
+
+inline uint32_t BlockGuestAddress(hir::Block* block) {
+  for (auto s = block->instr_head; s; s = s->next) {
+    if (s->opcode == &hir::OPCODE_SOURCE_OFFSET_info) {
+      return uint32_t(s->src1.offset);
+    }
+  }
+  return 0;
+}
+
+}  // namespace passes
+}  // namespace compiler
+}  // namespace cpu
+}  // namespace xe
+
+#endif  // XENIA_CPU_COMPILER_PASSES_BACK_EDGE_WALK_H_

--- a/src/xenia/cpu/compiler/passes/preempt_check_injection_pass.cc
+++ b/src/xenia/cpu/compiler/passes/preempt_check_injection_pass.cc
@@ -12,6 +12,7 @@
 #include <unordered_set>
 
 #include "xenia/base/cvar.h"
+#include "xenia/cpu/compiler/passes/back_edge_walk.h"
 #include "xenia/cpu/hir/hir_builder.h"
 
 DECLARE_bool(guest_scheduler);
@@ -45,58 +46,22 @@ bool PreemptCheckInjectionPass::Run(HIRBuilder* builder) {
   if (!cvars::guest_scheduler || !builder->first_block()) {
     return true;
   }
-  // Blocks are laid out in guest address order, so every intra-function cycle
-  // branches to an already-seen block. Calls, recursion and indirect branches
-  // (bcctr lowers to CallIndirect) re-enter at the entry block.
-  std::unordered_set<Block*> seen;
+  // Calls, recursion and indirect branches re-enter at the entry block.
   std::unordered_set<Block*> check_blocks;
   check_blocks.insert(builder->first_block());
-  for (auto block = builder->first_block(); block != nullptr;
-       block = block->next) {
-    seen.insert(block);
-    // Scan every instruction: a back-edge is not always in the trailing
-    // branch run. A loop ending its block with a call hides the loop branch
-    // from a tail-backward walk, leaving it to spin with no safepoint.
-    for (auto instr = block->instr_head; instr != nullptr;
-         instr = instr->next) {
-      Label* label = nullptr;
-      if (instr->opcode == &OPCODE_BRANCH_info) {
-        label = instr->src1.label;
-      } else if (instr->opcode == &OPCODE_BRANCH_TRUE_info ||
-                 instr->opcode == &OPCODE_BRANCH_FALSE_info) {
-        label = instr->src2.label;
-      }
-      if (label && label->block && seen.count(label->block)) {
-        check_blocks.insert(label->block);
-      }
-    }
-  }
+  ForEachBackEdge(builder, [&check_blocks](Block* header, Block*) {
+    check_blocks.insert(header);
+  });
   for (auto block : check_blocks) {
-    // A block holding only fake instructions falls through, so the check
-    // lands in the first real successor, still on every cycle through it.
-    for (auto b = block; b != nullptr; b = b->next) {
-      auto first = b->instr_head;
-      for (; first && first->IsFake(); first = first->next) {
-      }
-      if (first) {
-        if (first->GetOpcodeNum() != OPCODE_CHECK_PREEMPT) {
-          // Carry the guest address of the safepoint so the backend can record
-          // where a fiber last checked in. A fiber that stops yielding is
-          // otherwise only locatable by its link register, which points at the
-          // last call it made rather than the loop it is stuck in.
-          uint32_t guest_address = 0;
-          for (auto s = b->instr_head; s; s = s->next) {
-            if (s->opcode == &OPCODE_SOURCE_OFFSET_info) {
-              guest_address = uint32_t(s->src1.offset);
-              break;
-            }
-          }
-          Instr* check = builder->CheckPreempt();
-          check->src1.offset = guest_address;
-          check->MoveBefore(first);
-        }
-        break;
-      }
+    Instr* first = FirstRealInstr(block);
+    if (first && first->GetOpcodeNum() != OPCODE_CHECK_PREEMPT) {
+      // Carry the guest address of the safepoint so the backend can record
+      // where a fiber last checked in. A fiber that stops yielding is
+      // otherwise only locatable by its link register, which points at the
+      // last call it made rather than the loop it is stuck in.
+      Instr* check = builder->CheckPreempt();
+      check->src1.offset = BlockGuestAddress(first->block);
+      check->MoveBefore(first);
     }
   }
   return true;

--- a/src/xenia/cpu/compiler/passes/spin_wait_injection_pass.cc
+++ b/src/xenia/cpu/compiler/passes/spin_wait_injection_pass.cc
@@ -1,0 +1,156 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/cpu/compiler/passes/spin_wait_injection_pass.h"
+
+#include <algorithm>
+#include <unordered_set>
+
+#include "xenia/cpu/compiler/passes/back_edge_walk.h"
+#include "xenia/cpu/cpu_flags.h"
+#include "xenia/cpu/hir/hir_builder.h"
+
+namespace xe {
+namespace cpu {
+namespace compiler {
+namespace passes {
+
+using namespace xe::cpu::hir;
+
+SpinWaitInjectionPass::SpinWaitInjectionPass() : CompilerPass() {}
+
+SpinWaitInjectionPass::~SpinWaitInjectionPass() {}
+
+namespace {
+
+struct LoopShape {
+  uint32_t guest_lo = UINT32_MAX;
+  uint32_t guest_hi = 0;
+  bool has_memory_store = false;
+  bool has_memory_load = false;
+  bool has_call = false;
+  bool has_indirect_branch = false;
+  bool has_induction_variable = false;
+};
+
+// store_context(O, add(load_context(O), constant)): the loop is scanning.
+bool IsInductionStore(Instr* instr) {
+  if (instr->GetOpcodeNum() != OPCODE_STORE_CONTEXT) {
+    return false;
+  }
+  Value* stored = instr->src2.value;
+  if (!stored || !stored->def) {
+    return false;
+  }
+  Instr* def = stored->def;
+  if (def->GetOpcodeNum() != OPCODE_ADD && def->GetOpcodeNum() != OPCODE_SUB) {
+    return false;
+  }
+  Value* counted = nullptr;
+  if (def->src2.value && def->src2.value->IsConstant()) {
+    counted = def->src1.value;
+  } else if (def->src1.value && def->src1.value->IsConstant()) {
+    counted = def->src2.value;
+  }
+  if (!counted || !counted->def) {
+    return false;
+  }
+  Instr* load = counted->def;
+  return load->GetOpcodeNum() == OPCODE_LOAD_CONTEXT &&
+         load->src1.offset == instr->src1.offset;
+}
+
+LoopShape ScanLoop(Block* header, Block* latch) {
+  LoopShape shape;
+  for (Block* b = header; b != nullptr; b = b->next) {
+    for (auto instr = b->instr_head; instr != nullptr; instr = instr->next) {
+      const Opcode num = instr->GetOpcodeNum();
+      switch (num) {
+        case OPCODE_SOURCE_OFFSET: {
+          const uint32_t addr = uint32_t(instr->src1.offset);
+          shape.guest_lo = std::min(shape.guest_lo, addr);
+          shape.guest_hi = std::max(shape.guest_hi, addr);
+          break;
+        }
+        case OPCODE_STORE:
+        case OPCODE_STORE_OFFSET:
+        case OPCODE_STORE_MMIO:
+        case OPCODE_MEMSET:
+        case OPCODE_ATOMIC_COMPARE_EXCHANGE:
+          shape.has_memory_store = true;
+          break;
+        case OPCODE_LOAD:
+        case OPCODE_LOAD_OFFSET:
+        case OPCODE_LOAD_MMIO:
+          shape.has_memory_load = true;
+          break;
+        case OPCODE_CALL:
+        case OPCODE_CALL_TRUE:
+          shape.has_call = true;
+          break;
+        case OPCODE_STORE_CONTEXT:
+          if (IsInductionStore(instr)) {
+            shape.has_induction_variable = true;
+          }
+          break;
+        case OPCODE_CALL_INDIRECT:
+        case OPCODE_CALL_INDIRECT_TRUE:
+        case OPCODE_CALL_EXTERN:
+          shape.has_indirect_branch = true;
+          break;
+        default:
+          break;
+      }
+    }
+    if (b == latch) {
+      break;
+    }
+  }
+  return shape;
+}
+
+}  // namespace
+
+bool SpinWaitInjectionPass::Run(HIRBuilder* builder) {
+  if (!cvars::spin_wait_yield_after || !builder->first_block()) {
+    return true;
+  }
+  std::unordered_set<Block*> tagged;
+  ForEachBackEdge(builder, [&](Block* header, Block* latch) {
+    if (tagged.count(header)) {
+      return;
+    }
+    LoopShape shape = ScanLoop(header, latch);
+    if (shape.guest_lo > shape.guest_hi) {
+      return;  // no source offsets to size the loop with
+    }
+    const uint32_t span = (shape.guest_hi - shape.guest_lo) / 4 + 1;
+    if (span > kMaxBodyGuestInstrs || shape.has_memory_store ||
+        !shape.has_memory_load || !shape.has_call ||
+        shape.has_indirect_branch || shape.has_induction_variable) {
+      return;
+    }
+    Instr* first = FirstRealInstr(header);
+    if (!first) {
+      return;
+    }
+    if (first->GetOpcodeNum() != OPCODE_DELAY_EXECUTION) {
+      Instr* delay = builder->DelayExecution(DELAY_EXECUTION_INJECTED);
+      delay->src1.offset = BlockGuestAddress(header);
+      delay->MoveBefore(first);
+    }
+    tagged.insert(header);
+  });
+  return true;
+}
+
+}  // namespace passes
+}  // namespace compiler
+}  // namespace cpu
+}  // namespace xe

--- a/src/xenia/cpu/compiler/passes/spin_wait_injection_pass.h
+++ b/src/xenia/cpu/compiler/passes/spin_wait_injection_pass.h
@@ -1,0 +1,37 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_CPU_COMPILER_PASSES_SPIN_WAIT_INJECTION_PASS_H_
+#define XENIA_CPU_COMPILER_PASSES_SPIN_WAIT_INJECTION_PASS_H_
+
+#include "xenia/cpu/compiler/compiler_pass.h"
+
+namespace xe {
+namespace cpu {
+namespace compiler {
+namespace passes {
+
+// Tags spin-shaped loop headers with DELAY_EXECUTION_INJECTED so the a64
+// backend can release the core. Gated on --spin_wait_yield_after.
+class SpinWaitInjectionPass : public CompilerPass {
+ public:
+  SpinWaitInjectionPass();
+  ~SpinWaitInjectionPass() override;
+
+  bool Run(hir::HIRBuilder* builder) override;
+
+  static constexpr uint32_t kMaxBodyGuestInstrs = 8;
+};
+
+}  // namespace passes
+}  // namespace compiler
+}  // namespace cpu
+}  // namespace xe
+
+#endif  // XENIA_CPU_COMPILER_PASSES_SPIN_WAIT_INJECTION_PASS_H_

--- a/src/xenia/cpu/cpu_flags.cc
+++ b/src/xenia/cpu/cpu_flags.cc
@@ -65,3 +65,17 @@ DEFINE_bool(break_condition_truncate, true, "truncate value to 32-bits", "CPU");
 
 DEFINE_bool(break_on_debugbreak, true, "int3 on JITed __debugbreak requests.",
             "CPU");
+
+DEFINE_uint32(db16cyc_yield_after, 2,
+              "Consecutive guest db16cyc delays before the thread sleeps "
+              "instead of spinning; 0 disables.",
+              "CPU");
+
+DEFINE_uint32(spin_wait_yield_after, 100000,
+              "Iterations of a spin-shaped guest loop before the thread "
+              "sleeps; 0 disables the pass.",
+              "CPU");
+
+DEFINE_uint32(spin_wait_max_iter_ns, 1000,
+              "Longest average iteration, in ns, that still counts as a wait.",
+              "CPU");

--- a/src/xenia/cpu/cpu_flags.h
+++ b/src/xenia/cpu/cpu_flags.h
@@ -36,4 +36,8 @@ DECLARE_bool(break_condition_truncate);
 
 DECLARE_bool(break_on_debugbreak);
 
+DECLARE_uint32(db16cyc_yield_after);
+DECLARE_uint32(spin_wait_yield_after);
+DECLARE_uint32(spin_wait_max_iter_ns);
+
 #endif  // XENIA_CPU_CPU_FLAGS_H_

--- a/src/xenia/cpu/hir/hir_builder.cc
+++ b/src/xenia/cpu/hir/hir_builder.cc
@@ -1377,8 +1377,8 @@ void HIRBuilder::MemoryBarrier() { AppendInstr(OPCODE_MEMORY_BARRIER_info, 0); }
 
 void HIRBuilder::LoadBarrier() { AppendInstr(OPCODE_LOAD_BARRIER_info, 0); }
 
-void HIRBuilder::DelayExecution() {
-  AppendInstr(OPCODE_DELAY_EXECUTION_info, 0);
+Instr* HIRBuilder::DelayExecution(uint16_t flags) {
+  return AppendInstr(OPCODE_DELAY_EXECUTION_info, flags);
 }
 void HIRBuilder::SetRoundingMode(Value* value) {
   ASSERT_INTEGER_TYPE(value);

--- a/src/xenia/cpu/hir/hir_builder.h
+++ b/src/xenia/cpu/hir/hir_builder.h
@@ -217,7 +217,7 @@ class HIRBuilder {
                     CacheControlType type);
   void MemoryBarrier();
   void LoadBarrier();
-  void DelayExecution();
+  Instr* DelayExecution(uint16_t flags = 0);
   void SetRoundingMode(Value* value);
   Value* Max(Value* value1, Value* value2);
   Value* VectorMax(Value* value1, Value* value2, TypeName part_type,

--- a/src/xenia/cpu/hir/opcodes.h
+++ b/src/xenia/cpu/hir/opcodes.h
@@ -26,6 +26,11 @@ enum BranchFlags {
   BRANCH_UNLIKELY = (1 << 2),
 };
 
+enum DelayExecutionFlags {
+  // SpinWaitInjectionPass; the loop header's guest address is in src1.offset.
+  DELAY_EXECUTION_INJECTED = (1 << 0),
+};
+
 enum RoundMode {
   // to zero/nearest/etc
   ROUND_TO_ZERO = 0,

--- a/src/xenia/cpu/ppc/ppc_translator.cc
+++ b/src/xenia/cpu/ppc/ppc_translator.cc
@@ -68,6 +68,8 @@ PPCTranslator::PPCTranslator(PPCFrontend* frontend) : frontend_(frontend) {
   // Preemption safepoints for the guest scheduler. No-op when it is off.
   compiler_->AddPass(std::make_unique<passes::PreemptCheckInjectionPass>());
 
+  compiler_->AddPass(std::make_unique<passes::SpinWaitInjectionPass>());
+
   // Passes are executed in the order they are added. Multiple of the same
   // pass type may be used.
 

--- a/src/xenia/kernel/guest_scheduler.cc
+++ b/src/xenia/kernel/guest_scheduler.cc
@@ -64,6 +64,15 @@ static constexpr uint32_t kMaxIrqlPreemptDefers = 4096;
 // Reporting threshold for the lock case, which is never forced.
 static constexpr uint32_t kLockPreemptDeferReport = 65536;
 
+// Sleeping a fiber would stall its dispatch thread.
+static void ReleaseSpinWait(void* /*raw_context*/, uint64_t sleep_ns) {
+  if (XThread::GetCurrentFiberThread()) {
+    GuestScheduler::SpinYield();
+  } else {
+    xe::threading::NanoSleep(int64_t(sleep_ns));
+  }
+}
+
 // JIT safepoint handler. The cold path cleared the flag, so the deferred
 // cases re-set it to retry at the next safepoint.
 static void PreemptCurrentFiber(void* /*raw_context*/) {
@@ -177,6 +186,7 @@ void GuestScheduler::EnsureStarted() {
     return;
   }
   xe::cpu::backend::preempt_yield_handler = &PreemptCurrentFiber;
+  xe::cpu::backend::spin_wait_release_handler = &ReleaseSpinWait;
   // Not in the ctor, which runs before per-title cvar overrides are applied.
   double ticks_per_us = CalibrateTicksPerUs();
   ticks_per_us_ = ticks_per_us;


### PR DESCRIPTION
Guest wait loops stall a core for the whole wait, whose length is set by
the event being waited for rather than by anything in the loop. Two
shapes are handled, each through a new
backend::spin_wait_release_handler (the same shape as
preempt_yield_handler): GuestScheduler::EnsureStarted installs a handler
that yields a guest fiber (GuestScheduler::SpinYield) and NanoSleeps a
plain host thread; with no handler installed the backend NanoSleeps
directly. Sleeping a fiber from JIT code would stall its dispatch host
thread while co-resident fibers, possibly the one it waits on, cannot
run.

db16cyc loops. db16cyc lowers to a coalesced isb, so a wait loop built
from it spins in the core. Count consecutive delays per guest thread in
the backend context, restarting the count when two delays are more than
1us apart, and on the Nth consecutive delay give up the core for 60us
instead of stalling. --db16cyc_yield_after selects N (default 2; 0
restores the plain isb). The sleep length and the gap are constants:
tuning them measured null. With the default of 2, any db16cyc loop
sleeps on its second consecutive delay, including the or r31,r31,r31
spin-lock idiom.

Loops without the hint. SpinWaitInjectionPass tags the back-edge target
of loops of at most 8 guest instructions that contain a memory load and
a direct call but no memory store, no indirect or extern call and no
induction variable, with a DELAY_EXECUTION carrying the new
DELAY_EXECUTION_INJECTED flag and the loop header's guest address in
src1.offset, the way CHECK_PREEMPT names its safepoint. The back-edge
walk and the header placement are shared with PreemptCheckInjectionPass
through back_edge_walk.h. The a64 backend lowers the tag to a six-
instruction per-thread counter. At --spin_wait_yield_after iterations
(default 100000) a cold helper checks that the iterations since the last
reset averaged under --spin_wait_max_iter_ns (default 1000) each; if so
it releases the core through the handler and re-arms so the next 64
iterations re-trip, otherwise it restarts the count. State is keyed to
the loop header, so a trip from a different site restarts tracking and
the first escalation of a site costs two thresholds of iterations.

x64 is unchanged: it does not emit the db16cyc release and emits nothing
for the injected form, so the pass changes no x64 code generation.

Measured with --guest_scheduler=false, one binary per A/B with only the
cvar under test changed: db16cyc release (0 vs 2) on the Halo 3 menu,
-4.99% process CPU with four interleaved pairs agreeing
(-6.73/-4.11/-4.38/-4.75%); loop tagging on GTA IV (docks area), three
runs of three interleaved pairs, -13.95/-14.91/-14.31% process CPU with
throughput unchanged, and zero escalations logged at the Halo 3 menu, at
the Halo Reach menu and in the Halo Reach campaign. Process CPU was
measured; lock hand-off latency and frame-time variance were not. The
PPC test corpus passes 169,044/169,044; it contains no db16cyc and no
tagged loop, so it covers the unchanged sequences only. Not measured:
the fiber configuration (--guest_scheduler=true, the default), where
the handler yields instead of sleeping; and x64.