### PR TITLE
[X64] Vectorize average/pack/vmrg sequences; btr/bts single-bit masks

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_seq_vector.cc
+++ b/src/xenia/cpu/backend/x64/x64_seq_vector.cc
@@ -2077,6 +2077,18 @@ struct VECTOR_ROTATE_LEFT_V128
 };
 EMITTER_OPCODE_TABLE(OPCODE_VECTOR_ROTATE_LEFT, VECTOR_ROTATE_LEFT_V128);
 
+// A constant operand may already occupy xmm0-xmm3.
+static Xbyak::Xmm PickFreeScratchXmm(const Xbyak::Xmm& a, const Xbyak::Xmm& b,
+                                     const Xbyak::Xmm& c) {
+  for (int idx = 0; idx < 4; ++idx) {
+    if (idx != a.getIdx() && idx != b.getIdx() && idx != c.getIdx()) {
+      return Xbyak::Xmm(idx);
+    }
+  }
+  assert_always();
+  return Xbyak::Xmm(0);
+}
+
 struct VECTOR_AVERAGE
     : Sequence<VECTOR_AVERAGE,
                I<OPCODE_VECTOR_AVERAGE, V128Op, V128Op, V128Op>> {
@@ -2089,106 +2101,43 @@ struct VECTOR_AVERAGE
           const TypeName part_type = static_cast<TypeName>(i_flags & 0xFF);
           const uint32_t arithmetic_flags = i_flags >> 8;
           bool is_unsigned = !!(arithmetic_flags & ARITHMETIC_UNSIGNED);
-          unsigned stack_offset_src1 = StackLayout::GUEST_SCRATCH;
-          unsigned stack_offset_src2 = StackLayout::GUEST_SCRATCH + 16;
           switch (part_type) {
             case INT8_TYPE:
               if (is_unsigned) {
                 e.vpavgb(dest, src1, src2);
               } else {
-                // todo: avx2 version or version that sign extends to two __m128
-
-                e.vmovdqa(e.ptr[e.rsp + stack_offset_src1], src1);
-                e.vmovdqa(e.ptr[e.rsp + stack_offset_src2], src2);
-
-                Xbyak::Label looper;
-
-                e.xor_(e.edx, e.edx);
-
-                e.L(looper);
-
-                e.movsx(e.ecx, e.byte[e.rsp + stack_offset_src2 + e.rdx]);
-                e.movsx(e.eax, e.byte[e.rsp + stack_offset_src1 + e.rdx]);
-
-                e.lea(e.ecx, e.ptr[e.ecx + e.eax + 1]);
-                e.sar(e.ecx, 1);
-                e.mov(e.byte[e.rsp + stack_offset_src1 + e.rdx], e.cl);
-
-                if (e.IsFeatureEnabled(kX64FlagsIndependentVars)) {
-                  e.inc(e.edx);
-                } else {
-                  e.add(e.edx, 1);
-                }
-
-                e.cmp(e.edx, 16);
-                e.jnz(looper);
-                e.vmovdqa(dest, e.ptr[e.rsp + stack_offset_src1]);
+                // Flipping the sign bits maps signed lanes onto unsigned
+                // order-preservingly.
+                Xbyak::Xmm tmp = PickFreeScratchXmm(src1, src2, dest);
+                e.vpxor(tmp, src1, e.GetXmmConstPtr(XMMSignMaskI8));
+                e.vpxor(dest, src2, e.GetXmmConstPtr(XMMSignMaskI8));
+                e.vpavgb(dest, tmp, dest);
+                e.vpxor(dest, dest, e.GetXmmConstPtr(XMMSignMaskI8));
               }
               break;
             case INT16_TYPE:
               if (is_unsigned) {
                 e.vpavgw(dest, src1, src2);
               } else {
-                e.vmovdqa(e.ptr[e.rsp + stack_offset_src1], src1);
-                e.vmovdqa(e.ptr[e.rsp + stack_offset_src2], src2);
-
-                Xbyak::Label looper;
-
-                e.xor_(e.edx, e.edx);
-
-                e.L(looper);
-
-                e.movsx(e.ecx, e.word[e.rsp + stack_offset_src2 + e.rdx]);
-                e.movsx(e.eax, e.word[e.rsp + stack_offset_src1 + e.rdx]);
-
-                e.lea(e.ecx, e.ptr[e.ecx + e.eax + 1]);
-                e.sar(e.ecx, 1);
-                e.mov(e.word[e.rsp + stack_offset_src1 + e.rdx], e.cx);
-
-                e.add(e.edx, 2);
-
-                e.cmp(e.edx, 16);
-                e.jnz(looper);
-                e.vmovdqa(dest, e.ptr[e.rsp + stack_offset_src1]);
+                Xbyak::Xmm tmp = PickFreeScratchXmm(src1, src2, dest);
+                e.vpxor(tmp, src1, e.GetXmmConstPtr(XMMSignMaskI16));
+                e.vpxor(dest, src2, e.GetXmmConstPtr(XMMSignMaskI16));
+                e.vpavgw(dest, tmp, dest);
+                e.vpxor(dest, dest, e.GetXmmConstPtr(XMMSignMaskI16));
               }
               break;
             case INT32_TYPE: {
-              // No 32bit averages in AVX.
-              e.vmovdqa(e.ptr[e.rsp + stack_offset_src1], src1);
-              e.vmovdqa(e.ptr[e.rsp + stack_offset_src2], src2);
-
-              Xbyak::Label looper;
-
-              e.xor_(e.edx, e.edx);
-
-              e.L(looper);
-              auto src2_current_ptr =
-                  e.dword[e.rsp + stack_offset_src2 + e.rdx];
-              auto src1_current_ptr =
-                  e.dword[e.rsp + stack_offset_src1 + e.rdx];
-
+              // (a | b) - ((a ^ b) >> 1): the rounding average without forming
+              // the sum.
+              Xbyak::Xmm tmp = PickFreeScratchXmm(src1, src2, dest);
+              e.vpor(tmp, src1, src2);
+              e.vpxor(dest, src1, src2);
               if (is_unsigned) {
-                // implicit zero-ext
-                e.mov(e.ecx, src2_current_ptr);
-                e.mov(e.eax, src1_current_ptr);
+                e.vpsrld(dest, dest, 1);
               } else {
-                e.movsxd(e.rcx, src2_current_ptr);
-                e.movsxd(e.rax, src1_current_ptr);
+                e.vpsrad(dest, dest, 1);
               }
-
-              e.lea(e.rcx, e.ptr[e.rcx + e.rax + 1]);
-              if (is_unsigned) {
-                e.shr(e.rcx, 1);
-              } else {
-                e.sar(e.rcx, 1);
-              }
-              e.mov(e.dword[e.rsp + stack_offset_src1 + e.rdx], e.ecx);
-
-              e.add(e.edx, 4);
-
-              e.cmp(e.edx, 16);
-              e.jnz(looper);
-              e.vmovdqa(dest, e.ptr[e.rsp + stack_offset_src1]);
+              e.vpsubd(dest, tmp, dest);
             } break;
 
             default:
@@ -2461,6 +2410,15 @@ struct PERMUTE_I32
       } else {
         src3 = i.src3;
       }
+      // vmrghw / vmrglw.
+      if (control == MakePermuteMask(0, 0, 1, 0, 0, 1, 1, 1)) {
+        e.vpunpckldq(i.dest, src2, src3);
+        return;
+      }
+      if (control == MakePermuteMask(0, 2, 1, 2, 0, 3, 1, 3)) {
+        e.vpunpckhdq(i.dest, src2, src3);
+        return;
+      }
       // Words 0-1 from src2 and 2-3 from src3 is exactly vshufps, one
       // instruction instead of two shuffles and a blend.
       constexpr uint32_t kSelectBits = MakePermuteMask(1, 0, 1, 0, 1, 0, 1, 0);
@@ -2584,12 +2542,35 @@ struct PERMUTE_V128
       }
 
       if (i.src1.is_constant) {
-        e.LoadConstantXmm(e.xmm2, i.src1.constant());
-        e.vxorps(e.xmm2, e.xmm2, e.GetXmmConstPtr(XMMSwapWordMask));
+        const vec128_t folded = FixupConstantShuf8(i.src1.constant());
+        // vmrghb / vmrglb: unpack (src3, src2), then swap the dword pairs back.
+        constexpr vec128_t kMrghbFolded =
+            vec128b(3, 19, 2, 18, 1, 17, 0, 16, 7, 23, 6, 22, 5, 21, 4, 20);
+        constexpr vec128_t kMrglbFolded = vec128b(
+            11, 27, 10, 26, 9, 25, 8, 24, 15, 31, 14, 30, 13, 29, 12, 28);
+        const bool mrgh = folded == kMrghbFolded;
+        if (mrgh || folded == kMrglbFolded) {
+          Xmm m_src2 = i.src2.is_constant ? e.xmm0 : Xmm(i.src2);
+          if (i.src2.is_constant) {
+            e.LoadConstantXmm(e.xmm0, i.src2.constant());
+          }
+          Xmm m_src3 = i.src3.is_constant ? e.xmm1 : Xmm(i.src3);
+          if (i.src3.is_constant) {
+            e.LoadConstantXmm(e.xmm1, i.src3.constant());
+          }
+          if (mrgh) {
+            e.vpunpcklbw(i.dest, m_src3, m_src2);
+          } else {
+            e.vpunpckhbw(i.dest, m_src3, m_src2);
+          }
+          e.vpshufd(i.dest, i.dest, 0xB1);
+          return;
+        }
+        e.LoadConstantXmm(e.xmm2, folded);
       } else {
         e.vxorps(e.xmm2, i.src1, e.GetXmmConstPtr(XMMSwapWordMask));
+        e.vpand(e.xmm2, e.GetXmmConstPtr(XMMPermuteByteMask));
       }
-      e.vpand(e.xmm2, e.GetXmmConstPtr(XMMPermuteByteMask));
 
       Xmm src2_shuf = e.xmm0;
       if (i.src2.value->IsConstantZero()) {
@@ -2651,6 +2632,28 @@ struct PERMUTE_V128
 
     assert_true(i.src1.is_constant);
 
+    // vmrghh / vmrglh.
+    {
+      const vec128_t masked = i.src1.constant() & vec128s(0xF);
+      const bool mrgh = masked == vec128s(0, 8, 1, 9, 2, 10, 3, 11);
+      if (mrgh || masked == vec128s(4, 12, 5, 13, 6, 14, 7, 15)) {
+        Xmm m_src2 = i.src2.is_constant ? e.xmm0 : Xmm(i.src2);
+        if (i.src2.is_constant) {
+          e.LoadConstantXmm(e.xmm0, i.src2.constant());
+        }
+        Xmm m_src3 = i.src3.is_constant ? e.xmm1 : Xmm(i.src3);
+        if (i.src3.is_constant) {
+          e.LoadConstantXmm(e.xmm1, i.src3.constant());
+        }
+        if (mrgh) {
+          e.vpunpcklwd(i.dest, m_src3, m_src2);
+        } else {
+          e.vpunpckhwd(i.dest, m_src3, m_src2);
+        }
+        e.vpshufd(i.dest, i.dest, 0xB1);
+        return;
+      }
+    }
     vec128_t perm = (i.src1.constant() & vec128s(0xF)) ^ vec128s(0x1);
     vec128_t perm_ctrl = vec128b(0);
     for (int i = 0; i < 8; i++) {
@@ -2664,17 +2667,16 @@ struct PERMUTE_V128
 
     if (i.src2.is_constant) {
       e.LoadConstantXmm(e.xmm1, i.src2.constant());
+      e.vpshufb(e.xmm1, e.xmm1, e.xmm0);
     } else {
-      e.vmovdqa(e.xmm1, i.src2);
+      e.vpshufb(e.xmm1, i.src2, e.xmm0);
     }
     if (i.src3.is_constant) {
       e.LoadConstantXmm(e.xmm2, i.src3.constant());
+      e.vpshufb(e.xmm2, e.xmm2, e.xmm0);
     } else {
-      e.vmovdqa(e.xmm2, i.src3);
+      e.vpshufb(e.xmm2, i.src3, e.xmm0);
     }
-
-    e.vpshufb(e.xmm1, e.xmm1, e.xmm0);
-    e.vpshufb(e.xmm2, e.xmm2, e.xmm0);
 
     uint8_t mask = 0;
     for (int i = 0; i < 8; i++) {
@@ -3037,78 +3039,32 @@ struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
     // Merge XZ and YW.
     e.vorps(i.dest, e.xmm0);
   }
-  static __m128i EmulatePack8_IN_16_UN_UN_SAT(void*, __m128i src1,
-                                              __m128i src2) {
-    alignas(16) uint16_t a[8];
-    alignas(16) uint16_t b[8];
-    alignas(16) uint8_t c[16];
-    _mm_store_si128(reinterpret_cast<__m128i*>(a), src1);
-    _mm_store_si128(reinterpret_cast<__m128i*>(b), src2);
-    for (int i = 0; i < 8; ++i) {
-      c[i] = uint8_t(std::max(uint16_t(0), std::min(uint16_t(255), a[i])));
-      c[i + 8] = uint8_t(std::max(uint16_t(0), std::min(uint16_t(255), b[i])));
-    }
-    return _mm_load_si128(reinterpret_cast<__m128i*>(c));
-  }
-  static __m128i EmulatePack8_IN_16_UN_UN(void*, __m128i src1, __m128i src2) {
-    alignas(16) uint8_t a[16];
-    alignas(16) uint8_t b[16];
-    alignas(16) uint8_t c[16];
-    _mm_store_si128(reinterpret_cast<__m128i*>(a), src1);
-    _mm_store_si128(reinterpret_cast<__m128i*>(b), src2);
-    for (int i = 0; i < 8; ++i) {
-      c[i] = a[i * 2];
-      c[i + 8] = b[i * 2];
-    }
-    return _mm_load_si128(reinterpret_cast<__m128i*>(c));
-  }
   static void Emit8_IN_16(X64Emitter& e, const EmitArgType& i, uint32_t flags) {
     // TODO(benvanik): handle src2 (or src1) being constant zero
     if (IsPackInUnsigned(flags)) {
       if (IsPackOutUnsigned(flags)) {
         if (IsPackOutSaturate(flags)) {
-          // unsigned -> unsigned + saturate
-#if XE_PLATFORM_WIN32
-          // Windows x64 ABI: __m128i is passed by implicit pointer
-          if (i.src1.is_constant) {
-            e.lea(e.GetNativeParam(0),
-                  e.StashConstantXmm(0, i.src1.constant()));
-          } else {
-            e.lea(e.GetNativeParam(0), e.StashXmm(0, i.src1));
-          }
-          if (i.src2.is_constant) {
-            e.lea(e.GetNativeParam(1),
-                  e.StashConstantXmm(1, i.src2.constant()));
-          } else {
-            e.lea(e.GetNativeParam(1), e.StashXmm(1, i.src2));
-          }
-#else
-          // Linux/Mac System V ABI: __m128i passed in xmm0/xmm1, return in xmm0
+          // vpackuswb saturates from signed words: clamp to 255 first so the
+          // pack is exact. Only xmm0-xmm3 are scratch and all four are in play
+          // here.
           auto src1 = GetInputRegOrConstant(e, i.src1, e.xmm3);
           auto src2 = GetInputRegOrConstant(e, i.src2, e.xmm1);
-          e.vmovaps(e.xmm0, src1);
-          e.vmovaps(e.xmm1, src2);
-#endif
-          e.CallNativeSafe(
-              reinterpret_cast<void*>(EmulatePack8_IN_16_UN_UN_SAT));
-          e.vmovaps(i.dest, e.xmm0);
+          e.vpcmpeqb(e.xmm2, e.xmm2, e.xmm2);  // 0x00FF per word, no
+          e.vpsrlw(e.xmm2, e.xmm2, 8);         // constant load needed
+          e.vpminuw(e.xmm0, src1, e.xmm2);
+          e.vpminuw(e.xmm1, src2, e.xmm2);
+          e.vpackuswb(i.dest, e.xmm0, e.xmm1);
           e.vpshufb(i.dest, i.dest, e.GetXmmConstPtr(XMMByteOrderMask));
         } else {
-          // unsigned -> unsigned
+          // unsigned -> unsigned (modulo): mask to the low byte so the pack is
+          // exact.
           auto src1 = GetInputRegOrConstant(e, i.src1, e.xmm3);
           auto src2 = GetInputRegOrConstant(e, i.src2, e.xmm1);
-
-#if XE_PLATFORM_WIN32
-          // Windows x64 ABI: __m128i is passed by implicit pointer
-          e.lea(e.GetNativeParam(0), e.StashXmm(0, src1));
-          e.lea(e.GetNativeParam(1), e.StashXmm(1, src2));
-#else
-          // Linux/Mac System V ABI: __m128i passed in xmm0/xmm1, return in xmm0
-          e.vmovaps(e.xmm0, src1);
-          e.vmovaps(e.xmm1, src2);
-#endif
-          e.CallNativeSafe(reinterpret_cast<void*>(EmulatePack8_IN_16_UN_UN));
-          e.vmovaps(i.dest, e.xmm0);
+          e.vpcmpeqb(e.xmm2, e.xmm2, e.xmm2);
+          e.vpsrlw(e.xmm2, e.xmm2, 8);
+          e.vpand(e.xmm0, src1, e.xmm2);
+          e.vpand(e.xmm1, src2, e.xmm2);
+          e.vpackuswb(i.dest, e.xmm0, e.xmm1);
           e.vpshufb(i.dest, i.dest, e.GetXmmConstPtr(XMMByteOrderMask));
         }
       } else {

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -1431,15 +1431,17 @@ EMITTER_OPCODE_TABLE(OPCODE_DID_SATURATE, DID_SATURATE);
 // An invalid operation with no NaN operand answers with the default QNaN, and
 // x86's is negative where PPC's is positive. Only a NaN result can need the
 // fixup, so the test stays off the result's dependency chain and the work goes
-// to a tail block. The arithmetic lands in xmm2 because dest may share a
-// register with a source, and the tail needs the operands to tell a propagated
-// NaN from a generated one.
+// to a tail block.
 template <typename ARGS, typename FN>
 static void EmitBinaryFpWithPpcDefaultNan_F64(X64Emitter& e, const ARGS& i,
                                               FN&& emit_op) {
+  // The tail reads the original operands, so an aliased dest stages via xmm2.
+  const bool aliased = (!i.src1.is_constant && i.dest.reg() == i.src1.reg()) ||
+                       (!i.src2.is_constant && i.dest.reg() == i.src2.reg());
+  const Xmm target = aliased ? e.xmm2 : i.dest.reg();
   Xbyak::Label& done = e.NewCachedLabel();
   Xbyak::Label& invalid =
-      e.AddToTail([i, &done](X64Emitter& e, Xbyak::Label& tail) {
+      e.AddToTail([i, aliased, &done](X64Emitter& e, Xbyak::Label& tail) {
         e.L(tail);
         Xbyak::Label propagate;
         // Re-derive rather than capture: a constant operand lives in xmm0 or
@@ -1454,15 +1456,19 @@ static void EmitBinaryFpWithPpcDefaultNan_F64(X64Emitter& e, const ARGS& i,
         e.vmovq(i.dest, e.rax);
         e.jmp(done, X64Emitter::T_NEAR);
         e.L(propagate);
-        e.vmovapd(i.dest, e.xmm2);
+        if (aliased) {
+          e.vmovapd(i.dest, e.xmm2);
+        }
         e.jmp(done, X64Emitter::T_NEAR);
       });
   Xmm src1 = GetInputRegOrConstant(e, i.src1, e.xmm0);
   Xmm src2 = GetInputRegOrConstant(e, i.src2, e.xmm1);
-  emit_op(e, e.xmm2, src1, src2);
-  e.vucomisd(e.xmm2, e.xmm2);
+  emit_op(e, target, src1, src2);
+  e.vucomisd(target, target);
   e.jp(invalid, X64Emitter::T_NEAR);
-  e.vmovapd(i.dest, e.xmm2);
+  if (aliased) {
+    e.vmovapd(i.dest, e.xmm2);
+  }
   e.L(done);
 }
 
@@ -2882,14 +2888,44 @@ struct AND_I32 : Sequence<AND_I32, I<OPCODE_AND, I32Op, I32Op, I32Op>> {
     EmitAndXX<AND_I32, Reg32>(e, i);
   }
 };
+// btr/bts is 5 bytes where movabs + and/or is 10; nothing consumes the flags.
+static bool TryEmitSingleBitMask(X64Emitter& e, const I64Op& dest,
+                                 const I64Op& src, uint64_t constant,
+                                 bool set) {
+  const uint64_t bit = set ? constant : ~constant;
+  if (!bit || (bit & (bit - 1))) {
+    return false;
+  }
+  if (static_cast<int64_t>(constant) ==
+      static_cast<int64_t>(static_cast<int32_t>(constant))) {
+    return false;
+  }
+  if (dest != src.reg()) {
+    e.mov(dest, src);
+  }
+  if (set) {
+    e.bts(dest, xe::tzcnt(bit));
+  } else {
+    e.btr(dest, xe::tzcnt(bit));
+  }
+  return true;
+}
 struct AND_I64 : Sequence<AND_I64, I<OPCODE_AND, I64Op, I64Op, I64Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
     if (i.src2.is_constant && i.src2.constant() == 0xFFFFFFFF) {
       // special case for rlwinm codegen
       e.mov(((Reg64)i.dest).cvt32(), ((Reg64)i.src1).cvt32());
-    } else {
-      EmitAndXX<AND_I64, Reg64>(e, i);
+      return;
     }
+    if (i.src2.is_constant && !i.src1.is_constant &&
+        TryEmitSingleBitMask(e, i.dest, i.src1, i.src2.constant(), false)) {
+      return;
+    }
+    if (i.src1.is_constant && !i.src2.is_constant &&
+        TryEmitSingleBitMask(e, i.dest, i.src2, i.src1.constant(), false)) {
+      return;
+    }
+    EmitAndXX<AND_I64, Reg64>(e, i);
   }
 };
 struct AND_V128 : Sequence<AND_V128, I<OPCODE_AND, V128Op, V128Op, V128Op>> {
@@ -3037,6 +3073,14 @@ struct OR_I32 : Sequence<OR_I32, I<OPCODE_OR, I32Op, I32Op, I32Op>> {
 };
 struct OR_I64 : Sequence<OR_I64, I<OPCODE_OR, I64Op, I64Op, I64Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
+    if (i.src2.is_constant && !i.src1.is_constant &&
+        TryEmitSingleBitMask(e, i.dest, i.src1, i.src2.constant(), true)) {
+      return;
+    }
+    if (i.src1.is_constant && !i.src2.is_constant &&
+        TryEmitSingleBitMask(e, i.dest, i.src2, i.src1.constant(), true)) {
+      return;
+    }
     EmitOrXX<OR_I64, Reg64>(e, i);
   }
 };


### PR DESCRIPTION
Several x64 sequences did per-lane work in scalar loops or through a
host call where SSE/AVX has a direct form:

  - VECTOR_AVERAGE signed i8/i16 spilled both sources to the stack and
    ran a 16- or 8-iteration movsx/lea/sar/store loop. vpavgb/vpavgw
    are unsigned, but flipping the sign bit of both inputs maps signed
    values onto unsigned ones order-preservingly, so the unsigned
    average comes out biased by exactly +128 (+32768) and one more flip
    removes it, with the same rounding.
  - VECTOR_AVERAGE i32 ran a 4-iteration loop because no 32-bit
    average instruction exists. (a | b) - ((a ^ b) >> 1) is the rounding
    average and never forms the sum, so it cannot overflow the lane; the
    shift (vpsrad or vpsrld) carries the signedness.
  - PACK 8_IN_16 unsigned->unsigned, saturating and modulo, called a
    host helper per execution with per-ABI operand stashing. vpackuswb
    saturates from signed words, so clamping to 255 with vpminuw (or
    masking to the low byte with vpand for the modulo form) first puts
    every word in range and turns that saturation into an exact copy.
  - PERMUTE with a constant control recognises the vmrg merges:
    vmrghw/vmrglw become one vpunpckldq/vpunpckhdq instead of two
    shuffles and a blend, and vmrghb/vmrglb/vmrghh/vmrglh become
    vpunpck{l,h}{bw,wd}(dest, src3, src2) plus a vpshufd dword-pair
    swap instead of the control load, xor, and, two vpshufb and a
    blend. Other constant byte controls get the word swap and index
    wrap folded into the loaded constant, and the halfword path
    shuffles straight from the sources under AVX's three-operand
    vpshufb instead of staging copies.
  - AND_I64/OR_I64 with a constant that clears or sets exactly one bit
    outside the imm32 range emit btr/bts (5 bytes) instead of a 10-byte
    movabs plus and/or. Masks that fit imm32 keep that form. Nothing in
    the backend consumes flags from AND/OR emission, so the different
    flag behaviour of btr/bts is unobservable.
  - EmitBinaryFpWithPpcDefaultNan_F64 computes straight into dest when
    dest does not share a register with a source; the staging copy
    through xmm2 is only needed when the NaN tail must still read the
    original operands.

Register discipline a maintainer must know: only xmm0-xmm3 are scratch
in this backend (xmm4 and up are allocatable), and constant operands are
materialised into those same scratch registers. The average sequences
take their temporary from PickFreeScratchXmm, which avoids whatever
scratch registers already hold a source or the destination. The pack
sequences stage a constant src1 in xmm3 and a constant src2 in xmm1;
xmm2 holds the mask and xmm0/xmm1 the clamped words, which works because
vpminuw/vpand read their sources before writing.

Evidence: this backend is not compiled on the arm64 host where the
change was developed. No x64 test run of the final code exists: the
corpus and differential results recorded during development predate a
later compile fix to the pack sequences. The 169,044-case PPC
instruction corpus must be run on an x86-64 host before this merges.
The only x64 timing evidence is per-test loop-bench cycle counts
(rdtscp, min of 30) from that earlier state, in which vavgsb/vavgsh
went from ~80,600 to ~40,900 cycles, vavgsw/vavguw from ~61,100 to
~40,700, and vpkuhum/vpkuhus from 100,700/120,900 to ~41,100, i.e. all
six reached the harness floor; and a corpus-weighted code-size total of
29,024,018 -> 28,229,471 bytes (-2.74%) for the btr/bts change alone.

Follow-up: the constant-operand materialisation preamble in the vmrg
byte and halfword paths is duplicated and could become a small helper.