### PR TITLE
[CPU] Eliminate dead condition-register stores with a liveness pass

### DIFF
--- a/src/xenia/cpu/compiler/compiler_passes.h
+++ b/src/xenia/cpu/compiler/compiler_passes.h
@@ -18,6 +18,7 @@
 #include "xenia/cpu/compiler/passes/control_flow_simplification_pass.h"
 #include "xenia/cpu/compiler/passes/data_flow_analysis_pass.h"
 #include "xenia/cpu/compiler/passes/dead_code_elimination_pass.h"
+#include "xenia/cpu/compiler/passes/dead_cr_store_elimination_pass.h"
 #include "xenia/cpu/compiler/passes/finalization_pass.h"
 #include "xenia/cpu/compiler/passes/memory_sequence_combination_pass.h"
 #include "xenia/cpu/compiler/passes/preempt_check_injection_pass.h"

--- a/src/xenia/cpu/compiler/passes/dead_cr_store_elimination_pass.cc
+++ b/src/xenia/cpu/compiler/passes/dead_cr_store_elimination_pass.cc
@@ -1,0 +1,214 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/cpu/compiler/passes/dead_cr_store_elimination_pass.h"
+
+#include <unordered_map>
+#include <vector>
+
+#include "xenia/base/cvar.h"
+#include "xenia/base/profiling.h"
+#include "xenia/cpu/ppc/ppc_context.h"
+
+DEFINE_bool(eliminate_dead_cr_stores, true,
+            "Drop condition-register stores that no path through the function "
+            "can observe.",
+            "CPU");
+
+DECLARE_bool(debug);
+DECLARE_bool(disable_context_promotion);
+DECLARE_bool(store_all_context_values);
+DECLARE_bool(full_optimization_even_with_debug);
+
+namespace xe {
+namespace cpu {
+namespace compiler {
+namespace passes {
+
+// TODO(benvanik): remove when enums redefined.
+using namespace xe::cpu::hir;
+
+using xe::cpu::hir::Block;
+using xe::cpu::hir::HIRBuilder;
+using xe::cpu::hir::Instr;
+
+namespace {
+
+// cr0..cr7 are the first 32 context bytes; one bit per byte here.
+constexpr uint32_t kCRBase =
+    static_cast<uint32_t>(offsetof(ppc::PPCContext, cr0));
+constexpr uint32_t kCRBytes = 8 * 4;
+constexpr uint32_t kAllCR = ~uint32_t(0);
+
+// PowerPC ABI: cr2-cr4 survive a call, the rest are the callee's to destroy.
+constexpr uint32_t kVolatileCR = 0x000000FFu     // cr0, cr1
+                                 | 0xFFF00000u;  // cr5, cr6, cr7
+
+uint32_t MaskForRange(uint32_t offset, uint32_t size) {
+  uint32_t mask = 0;
+  for (uint32_t byte = offset; byte < offset + size; ++byte) {
+    if (byte >= kCRBase && byte < kCRBase + kCRBytes) {
+      mask |= uint32_t(1) << (byte - kCRBase);
+    }
+  }
+  return mask;
+}
+
+Block* BranchTarget(const Instr* i) {
+  switch (i->GetOpcodeNum()) {
+    case OPCODE_BRANCH:
+      return i->src1.label ? i->src1.label->block : nullptr;
+    case OPCODE_BRANCH_TRUE:
+    case OPCODE_BRANCH_FALSE:
+      return i->src2.label ? i->src2.label->block : nullptr;
+    default:
+      return nullptr;
+  }
+}
+
+enum class CallKind {
+  kNotACall,
+  kUnconditional,
+  kConditional,
+};
+
+CallKind ClassifyCall(const Instr* i) {
+  switch (i->GetOpcodeNum()) {
+    case OPCODE_CALL:
+    case OPCODE_CALL_INDIRECT:
+    case OPCODE_CALL_EXTERN:
+      // A tail call is an exit, not a clobber.
+      return (i->flags & CALL_TAIL) ? CallKind::kNotACall
+                                    : CallKind::kUnconditional;
+    case OPCODE_CALL_TRUE:
+    case OPCODE_CALL_INDIRECT_TRUE:
+      return (i->flags & CALL_TAIL) ? CallKind::kNotACall
+                                    : CallKind::kConditional;
+    default:
+      return CallKind::kNotACall;
+  }
+}
+
+uint32_t TransferBlock(Block* block, uint32_t live, bool apply,
+                       const std::unordered_map<Block*, size_t>& index,
+                       const std::vector<uint32_t>& live_in) {
+  auto live_in_of = [&](Block* dest) -> uint32_t {
+    if (!dest) {
+      return kAllCR;
+    }
+    auto it = index.find(dest);
+    return it == index.end() ? kAllCR : live_in[it->second];
+  };
+
+  Instr* i = block->instr_tail;
+  while (i) {
+    Instr* prev = i->prev;
+    const Opcode num = i->GetOpcodeNum();
+    if (Block* target = BranchTarget(i)) {
+      // Branches are VOLATILE but read no context: only the target's live-in.
+      if (num == OPCODE_BRANCH) {
+        live = live_in_of(target);
+      } else {
+        live |= live_in_of(target);
+      }
+    } else if (num == OPCODE_LOAD_CONTEXT) {
+      live |= MaskForRange(static_cast<uint32_t>(i->src1.offset),
+                           static_cast<uint32_t>(GetTypeSize(i->dest->type)));
+    } else if (num == OPCODE_STORE_CONTEXT) {
+      const uint32_t offset = static_cast<uint32_t>(i->src1.offset);
+      const uint32_t size =
+          static_cast<uint32_t>(GetTypeSize(i->src2.value->type));
+      const uint32_t mask = MaskForRange(offset, size);
+      if (mask && offset >= kCRBase && offset + size <= kCRBase + kCRBytes) {
+        if (!(mask & live)) {
+          if (apply) {
+            i->UnlinkAndNOP();
+          }
+        } else {
+          live &= ~mask;
+        }
+      }
+    } else if (const CallKind kind = ClassifyCall(i);
+               kind != CallKind::kNotACall) {
+      if (kind == CallKind::kUnconditional) {
+        live &= ~kVolatileCR;
+      }
+    } else if (i->opcode->flags & OPCODE_FLAG_VOLATILE) {
+      live = kAllCR;
+    }
+    i = prev;
+  }
+  return live;
+}
+
+}  // namespace
+
+DeadCRStoreEliminationPass::DeadCRStoreEliminationPass() : CompilerPass() {}
+
+DeadCRStoreEliminationPass::~DeadCRStoreEliminationPass() = default;
+
+bool DeadCRStoreEliminationPass::Run(HIRBuilder* builder) {
+  SCOPE_profile_cpu_f("cpu");
+
+  if (!cvars::eliminate_dead_cr_stores || cvars::disable_context_promotion ||
+      !(cvars::full_optimization_even_with_debug ||
+        (!cvars::debug && !cvars::store_all_context_values))) {
+    return true;
+  }
+
+  std::vector<Block*> blocks;
+  std::unordered_map<Block*, size_t> index;
+  for (auto block = builder->first_block(); block; block = block->next) {
+    index.emplace(block, blocks.size());
+    blocks.push_back(block);
+  }
+  if (blocks.empty()) {
+    return true;
+  }
+
+  std::vector<uint32_t> live_in(blocks.size(), 0);
+  auto live_out_of = [&](Block* block) -> uint32_t {
+    if (!block->outgoing_edge_head) {
+      return kAllCR;
+    }
+    uint32_t live_out = 0;
+    for (auto edge = block->outgoing_edge_head; edge;
+         edge = edge->outgoing_next) {
+      auto it = index.find(edge->dest);
+      if (it == index.end()) {
+        return kAllCR;
+      }
+      live_out |= live_in[it->second];
+    }
+    return live_out;
+  };
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (size_t n = blocks.size(); n-- > 0;) {
+      const uint32_t result = TransferBlock(blocks[n], live_out_of(blocks[n]),
+                                            false, index, live_in);
+      if (result != live_in[n]) {
+        live_in[n] = result;
+        changed = true;
+      }
+    }
+  }
+
+  for (Block* block : blocks) {
+    TransferBlock(block, live_out_of(block), true, index, live_in);
+  }
+
+  return true;
+}
+
+}  // namespace passes
+}  // namespace compiler
+}  // namespace cpu
+}  // namespace xe

--- a/src/xenia/cpu/compiler/passes/dead_cr_store_elimination_pass.h
+++ b/src/xenia/cpu/compiler/passes/dead_cr_store_elimination_pass.h
@@ -1,0 +1,34 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_CPU_COMPILER_PASSES_DEAD_CR_STORE_ELIMINATION_PASS_H_
+#define XENIA_CPU_COMPILER_PASSES_DEAD_CR_STORE_ELIMINATION_PASS_H_
+
+#include "xenia/cpu/compiler/compiler_pass.h"
+
+namespace xe {
+namespace cpu {
+namespace compiler {
+namespace passes {
+
+// Removes condition-register stores that no path can observe.
+class DeadCRStoreEliminationPass : public CompilerPass {
+ public:
+  DeadCRStoreEliminationPass();
+  ~DeadCRStoreEliminationPass() override;
+
+  bool Run(hir::HIRBuilder* builder) override;
+};
+
+}  // namespace passes
+}  // namespace compiler
+}  // namespace cpu
+}  // namespace xe
+
+#endif  // XENIA_CPU_COMPILER_PASSES_DEAD_CR_STORE_ELIMINATION_PASS_H_

--- a/src/xenia/cpu/ppc/ppc_translator.cc
+++ b/src/xenia/cpu/ppc/ppc_translator.cc
@@ -68,6 +68,9 @@ PPCTranslator::PPCTranslator(PPCFrontend* frontend) : frontend_(frontend) {
   // Preemption safepoints for the guest scheduler. No-op when it is off.
   compiler_->AddPass(std::make_unique<passes::PreemptCheckInjectionPass>());
 
+  // Before context promotion, while CR reads are still load_context.
+  compiler_->AddPass(std::make_unique<passes::DeadCRStoreEliminationPass>());
+
   // Passes are executed in the order they are added. Multiple of the same
   // pass type may be used.
 


### PR DESCRIPTION
Every PPC compare materialises all three bits of a CR field and stores
each one to the context, while the branch that follows consumes only
the SSA value. ContextPromotionPass's dead-store elimination is
block-local and keeps every store that reaches the end of its block, so
those stores survive whenever the compare and the next write of the
field sit in different blocks, which is the common case in a loop.

DeadCRStoreEliminationPass is a backward liveness analysis over the 32
context bytes cr0..cr7 (one bit each, so a live set is a uint32_t). It
iterates to a fixpoint over the blocks and then walks each block once
more, unlinking every store_context into the CR whose bytes are not
live at that point. The transfer function, walking backwards:

  - load_context of CR bytes makes them live;
  - a store_context wholly inside the CR kills its bytes, or is removed
    when none of them is live;
  - a plain CALL/CALL_INDIRECT/CALL_EXTERN kills the volatile fields
    (cr0, cr1, cr5-cr7) and passes cr2-cr4 through; a conditional call
    kills nothing, because liveness is a union over paths; a tail call
    is an exit, not a clobber;
  - a branch takes its target's live-in set (unconditional) or adds it
    (conditional); it reads no context, and letting it fall into the
    blanket VOLATILE case would relight every bit;
  - any other VOLATILE instruction (return, trap, barrier) is assumed
    to read everything, and a block with no successors is live-out
    everything, since the caller sees the context after a return.

Dropping the store is the whole change: the compare feeding it loses
its only use and DeadCodeEliminationPass removes it. The pass runs
before ContextPromotionPass so every CR read the frontend emitted is
still a load_context, and it is gated behind eliminate_dead_cr_stores,
disable_context_promotion and the same debug switches as the
context-promotion dead-store elimination, since stripping stores costs
the debugger the register values it recovers from the context.

Two things a maintainer must know. First, the call rule assumes the
PowerPC ABI: a callee may destroy cr0, cr1 and cr5-cr7, so a value
stored to one of those before a call cannot be observed after it. For
CALL_EXTERN this also assumes no kernel export reads the caller's
volatile CR fields, which is true of every export today. Hand-written
guest assembly that reads a volatile CR field after a bl would change
behaviour. Second, a whole-function variant (drop any CR store nothing
in the function reads, which is what the ABI permits) was tried first
and failed 9,569 of the 169,048 PPC corpus cases, every one a CR
mismatch with no GPR, FPR or VR wrong: the test harness reads CR after
the function returns. Path liveness, which keeps a store that reaches a
return, is what the corpus accepts.

Evidence: 169,044/169,044 PPC corpus cases pass with the pass enabled.
No runtime measurement of the pass on its own is recorded.