### PR TITLE
[A64] Embed stackpoints, cheapen calls, track FPCR, move NaN fixups cold

### DIFF
--- a/src/xenia/cpu/backend/a64/a64_backend.cc
+++ b/src/xenia/cpu/backend/a64/a64_backend.cc
@@ -44,9 +44,6 @@
 #include "xenia/cpu/thread_state.h"
 #include "xenia/cpu/xex_module.h"
 
-DEFINE_int64(a64_max_stackpoints, 65536,
-             "Max number of host->guest stack mappings we can record.", "a64");
-
 DEFINE_bool(a64_enable_host_guest_stack_synchronization, true,
             "Records entries for guest/host stack mappings at function starts "
             "and checks for reentry at return sites. Has slight performance "
@@ -62,24 +59,25 @@ namespace a64 {
 // a guest address has not yet been compiled.
 uint64_t ResolveFunction(void* raw_context, uint64_t target_address);
 
-uint32_t FindStackpointSyncDepth(const A64BackendStackpoint* stackpoints,
-                                 uint32_t current_depth, uint32_t guest_sp) {
-  if (!stackpoints || current_depth == 0) {
-    return 0;
+const A64StackpointNode* FindStackpointSyncNode(const A64StackpointNode* head,
+                                                uint32_t guest_sp) {
+  if (!head) {
+    return nullptr;
   }
-
-  uint32_t idx = current_depth - 1;
+  const A64StackpointNode* node = head;
   uint32_t frames_skipped = 0;
-  while (idx != 0xFFFFFFFFu && guest_sp > stackpoints[idx].guest_stack_) {
-    --idx;
+  // Walking from head visits newest first, so a run of equal guest_stack_
+  // values stops at its newest node.
+  while (node && guest_sp > node->guest_stack_) {
+    node = node->prev_;
     ++frames_skipped;
   }
-
-  // >1 frames skipped = real longjmp, not an early SP restore.
-  if (idx == 0xFFFFFFFFu || frames_skipped <= 1) {
-    return 0;
+  // >1 frames skipped = real longjmp, not an early SP restore. Walking off
+  // the chain end means no live frame owns the target: no repair.
+  if (!node || frames_skipped <= 1) {
+    return nullptr;
   }
-  return idx + 1;
+  return node;
 }
 
 // ==========================================================================
@@ -91,15 +89,61 @@ class A64HelperEmitter : public A64Emitter {
 
   HostToGuestThunk EmitHostToGuestThunk();
   GuestToHostThunk EmitGuestToHostThunk();
+  GuestToHostThunk EmitGuestToHostThunkNoVec();
   ResolveFunctionThunk EmitResolveFunctionThunk();
   void* EmitGuestAndHostSynchronizeStackHelper();
   void* EmitVRsqrtefpHelper(void** out_vector_entry);
   void* EmitFrsqrteHelper();
+
+ private:
+  // Where each part of a helper starts, recorded as it is emitted.
+  struct CodeOffsets {
+    size_t prolog;
+    size_t prolog_stack_alloc;
+    size_t body;
+    size_t epilog;
+    size_t tail;
+  };
+
+  // Restores the guest scalar FPCR from the backend context (x19), skipping
+  // the context-synchronizing msr when FPCR already holds it. Clobbers
+  // x11/x12 only.
+  void EmitRestoreFpuFpcr();
+  // Emplaces the helper with sizes derived from the recorded offsets.
+  void* EmplaceHelper(const CodeOffsets& code_offsets, size_t stack_size,
+                      size_t lr_save_offset = 0);
 };
 
 A64HelperEmitter::A64HelperEmitter(A64Backend* backend,
                                    XbyakA64Allocator* allocator)
     : A64Emitter(backend, allocator) {}
+
+void A64HelperEmitter::EmitRestoreFpuFpcr() {
+  Xbyak_aarch64::Label fpcr_unchanged;
+  ldr(w11,
+      ptr(x19, static_cast<uint32_t>(offsetof(A64BackendContext, fpcr_fpu))));
+  mrs(x12, 3, 3, 4, 4, 0);  // mrs x12, FPCR
+  cmp(w11, w12);
+  b(Xbyak_aarch64::EQ, fpcr_unchanged);
+  msr(3, 3, 4, 4, 0, x11);
+  L(fpcr_unchanged);
+}
+
+void* A64HelperEmitter::EmplaceHelper(const CodeOffsets& code_offsets,
+                                      size_t stack_size,
+                                      size_t lr_save_offset) {
+  EmitFunctionInfo func_info = {};
+  func_info.code_size.total = getSize();
+  func_info.code_size.prolog = code_offsets.body - code_offsets.prolog;
+  func_info.code_size.body = code_offsets.epilog - code_offsets.body;
+  func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
+  func_info.code_size.tail = getSize() - code_offsets.tail;
+  func_info.prolog_stack_alloc_offset =
+      code_offsets.prolog_stack_alloc - code_offsets.prolog;
+  func_info.stack_size = stack_size;
+  func_info.lr_save_offset = lr_save_offset;
+  return Emplace(func_info);
+}
 
 // --------------------------------------------------------------------------
 // HostToGuestThunk
@@ -116,13 +160,7 @@ A64HelperEmitter::A64HelperEmitter(A64Backend* backend,
 // We save all callee-saved regs, set up context (x20) and membase (x21),
 // then call the target. On return, restore and return to host.
 HostToGuestThunk A64HelperEmitter::EmitHostToGuestThunk() {
-  struct {
-    size_t prolog;
-    size_t prolog_stack_alloc;
-    size_t body;
-    size_t epilog;
-    size_t tail;
-  } code_offsets = {};
+  CodeOffsets code_offsets = {};
 
   code_offsets.prolog = getSize();
 
@@ -160,9 +198,9 @@ HostToGuestThunk A64HelperEmitter::EmitHostToGuestThunk() {
                         offsetof(ppc::PPCContext, virtual_membase))));
   // Restore the guest scalar FPCR on every host->guest entry so host-side
   // work done before the call can't leak a stale rounding / non-IEEE mode.
-  ldr(w11,
-      ptr(x19, static_cast<uint32_t>(offsetof(A64BackendContext, fpcr_fpu))));
-  msr(3, 3, 4, 4, 0, x11);
+  // Conditional for the same reason as the guest->host thunk: the write is
+  // context-synchronizing and the value is usually already correct.
+  EmitRestoreFpuFpcr();
   // x0 still holds target, x2 holds return address.
   // The guest function's prolog stores x0 to GUEST_RET_ADDR on its stack
   // frame. Move the target to a scratch reg and put the guest return
@@ -196,18 +234,8 @@ HostToGuestThunk A64HelperEmitter::EmitHostToGuestThunk() {
 
   code_offsets.tail = getSize();
 
-  EmitFunctionInfo func_info = {};
-  func_info.code_size.total = getSize();
-  func_info.code_size.prolog = code_offsets.body - code_offsets.prolog;
-  func_info.code_size.body = code_offsets.epilog - code_offsets.body;
-  func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
-  func_info.code_size.tail = getSize() - code_offsets.tail;
-  func_info.prolog_stack_alloc_offset =
-      code_offsets.prolog_stack_alloc - code_offsets.prolog;
-  func_info.stack_size = thunk_stack;
-  func_info.lr_save_offset = 0x058;  // stp x29, x30, [sp, #0x50]
-
-  void* fn = Emplace(func_info);
+  void* fn = EmplaceHelper(code_offsets, thunk_stack,
+                           0x058);  // stp x29, x30, [sp, #0x50]
   return reinterpret_cast<HostToGuestThunk>(fn);
 }
 
@@ -222,13 +250,7 @@ HostToGuestThunk A64HelperEmitter::EmitHostToGuestThunk() {
 // We save volatile guest registers that we need to preserve across the
 // host call, then call the host function with context as the first arg.
 GuestToHostThunk A64HelperEmitter::EmitGuestToHostThunk() {
-  struct {
-    size_t prolog;
-    size_t prolog_stack_alloc;
-    size_t body;
-    size_t epilog;
-    size_t tail;
-  } code_offsets = {};
+  CodeOffsets code_offsets = {};
 
   code_offsets.prolog = getSize();
 
@@ -289,9 +311,13 @@ GuestToHostThunk A64HelperEmitter::EmitGuestToHostThunk() {
   // Host callbacks may change FPCR. Restore the guest scalar FPCR before
   // resuming the JIT so later guest ops observe the cached PPC mode.
   // x19 (backend context) is callee-saved, so it survives the host call.
-  ldr(w11,
-      ptr(x19, static_cast<uint32_t>(offsetof(A64BackendContext, fpcr_fpu))));
-  msr(3, 3, 4, 4, 0, x11);
+  //
+  // Read it back and skip the write when it already matches: `msr fpcr` is
+  // context-synchronizing, and host callbacks almost never change FPCR, so
+  // the common case is a read, a compare and a not-taken branch. Either way
+  // FPCR equals fpcr_fpu on the way out.
+  // x0 holds the host return value here and must not be touched.
+  EmitRestoreFpuFpcr();
 
   code_offsets.epilog = getSize();
 
@@ -317,18 +343,61 @@ GuestToHostThunk A64HelperEmitter::EmitGuestToHostThunk() {
 
   code_offsets.tail = getSize();
 
-  EmitFunctionInfo func_info = {};
-  func_info.code_size.total = getSize();
-  func_info.code_size.prolog = code_offsets.body - code_offsets.prolog;
-  func_info.code_size.body = code_offsets.epilog - code_offsets.body;
-  func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
-  func_info.code_size.tail = getSize() - code_offsets.tail;
-  func_info.prolog_stack_alloc_offset =
-      code_offsets.prolog_stack_alloc - code_offsets.prolog;
-  func_info.stack_size = g2h_stack;
-  func_info.lr_save_offset = 0x1C8;  // stp x29, x30, [sp, #0x1C0]
+  void* fn = EmplaceHelper(code_offsets, g2h_stack,
+                           0x1C8);  // stp x29, x30, [sp, #0x1C0]
+  return reinterpret_cast<GuestToHostThunk>(fn);
+}
 
-  void* fn = Emplace(func_info);
+// --------------------------------------------------------------------------
+// GuestToHostThunkNoVec
+// --------------------------------------------------------------------------
+// The same transition without the vector save/restore (28 Q registers, 896
+// bytes through a 464-byte frame), for call sites where no HIR value can be
+// live in q4-q31.
+//
+// That holds for every HIR-level call (CallExtern) because of how the HIR is
+// built, not because the register allocator checks it: a guest-to-guest
+// OPCODE_CALL emits a bare blr into another translated function, whose prolog
+// saves only x0/x30 and which then uses q4-q31 freely, so a value live in a
+// vector register across a CALL would already be broken; and
+// ContextPromotionPass stops at the first volatile instruction (a call or a
+// preempt check), so no promoted context value spans one either. The
+// allocator does not enforce this: a pass that hoists a value across a CALL
+// breaks it.
+//
+// CallNativeSafe is different: it is emitted *inside* a sequence (the inline
+// MMIO fallback, SpinWaitRelease, the memory tracers, the debug traps) where
+// operands genuinely are in flight, so it keeps the full thunk.
+GuestToHostThunk A64HelperEmitter::EmitGuestToHostThunkNoVec() {
+  CodeOffsets code_offsets = {};
+
+  code_offsets.prolog = getSize();
+
+  const size_t g2h_stack = 16;  // x29/x30 only, 16-byte aligned
+  sub(sp, sp, static_cast<uint32_t>(g2h_stack));
+  code_offsets.prolog_stack_alloc = getSize();
+  stp(x29, x30, ptr(sp, 0x00));
+
+  code_offsets.body = getSize();
+
+  mov(x9, x0);   // x9 = target function (scratch)
+  mov(x0, x20);  // x0 = PPCContext*
+  blr(x9);
+
+  // Same conditional FPCR restore as the full thunk, and the same
+  // postcondition: on the way out FPCR equals fpcr_fpu either way.
+  EmitRestoreFpuFpcr();
+
+  code_offsets.epilog = getSize();
+
+  ldp(x29, x30, ptr(sp, 0x00));
+  add(sp, sp, static_cast<uint32_t>(g2h_stack));
+  ret();
+
+  code_offsets.tail = getSize();
+
+  void* fn = EmplaceHelper(code_offsets, g2h_stack,
+                           0x08);  // stp x29, x30, [sp, #0x00]
   return reinterpret_cast<GuestToHostThunk>(fn);
 }
 
@@ -344,13 +413,7 @@ GuestToHostThunk A64HelperEmitter::EmitGuestToHostThunk() {
 //   x20 = context
 //   x30 = return address (from the BLR that got us here)
 ResolveFunctionThunk A64HelperEmitter::EmitResolveFunctionThunk() {
-  struct {
-    size_t prolog;
-    size_t prolog_stack_alloc;
-    size_t body;
-    size_t epilog;
-    size_t tail;
-  } code_offsets = {};
+  CodeOffsets code_offsets = {};
 
   code_offsets.prolog = getSize();
 
@@ -374,6 +437,13 @@ ResolveFunctionThunk A64HelperEmitter::EmitResolveFunctionThunk() {
   // x0 now holds the resolved host machine code address.
   mov(x9, x0);
 
+  // Host code may change FPCR; every guest entry point is emitted assuming
+  // the scalar FPU mode (see the emitter's entry-mode contract), so restore
+  // it before jumping in. Cold path - one resolve per call site, ever.
+  ldr(w11,
+      ptr(x19, static_cast<uint32_t>(offsetof(A64BackendContext, fpcr_fpu))));
+  msr(3, 3, 4, 4, 0, x11);
+
   code_offsets.epilog = getSize();
 
   // Restore x0 (guest return address) and saved regs.
@@ -387,18 +457,8 @@ ResolveFunctionThunk A64HelperEmitter::EmitResolveFunctionThunk() {
 
   code_offsets.tail = getSize();
 
-  EmitFunctionInfo func_info = {};
-  func_info.code_size.total = getSize();
-  func_info.code_size.prolog = code_offsets.body - code_offsets.prolog;
-  func_info.code_size.body = code_offsets.epilog - code_offsets.body;
-  func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
-  func_info.code_size.tail = getSize() - code_offsets.tail;
-  func_info.prolog_stack_alloc_offset =
-      code_offsets.prolog_stack_alloc - code_offsets.prolog;
-  func_info.stack_size = thunk_stack;
-  func_info.lr_save_offset = 0x058;  // stp x29, x30, [sp, #0x50]
-
-  void* fn = Emplace(func_info);
+  void* fn = EmplaceHelper(code_offsets, thunk_stack,
+                           0x058);  // stp x29, x30, [sp, #0x50]
   return reinterpret_cast<ResolveFunctionThunk>(fn);
 }
 
@@ -413,13 +473,7 @@ ResolveFunctionThunk A64HelperEmitter::EmitResolveFunctionThunk() {
 //   x19 = A64BackendContext*
 void* A64HelperEmitter::EmitGuestAndHostSynchronizeStackHelper() {
   using namespace Xbyak_aarch64;
-  struct {
-    size_t prolog;
-    size_t prolog_stack_alloc;
-    size_t body;
-    size_t epilog;
-    size_t tail;
-  } code_offsets = {};
+  CodeOffsets code_offsets = {};
 
   code_offsets.prolog = getSize();
   code_offsets.prolog_stack_alloc = getSize();
@@ -427,69 +481,48 @@ void* A64HelperEmitter::EmitGuestAndHostSynchronizeStackHelper() {
 
   // x19 = backend context pointer (already set up by HostToGuestThunk)
 
-  // x10 = stackpoints array pointer
-  ldr(x10, ptr(x19, static_cast<uint32_t>(
-                        offsetof(A64BackendContext, stackpoints))));
-  // w11 = current_stackpoint_depth
-  ldr(w11, ptr(x19, static_cast<uint32_t>(offsetof(A64BackendContext,
-                                                   current_stackpoint_depth))));
+  // x10 = target node computed by ResolveFunction.
+  ldr(x10, ptr(x19, static_cast<uint32_t>(offsetof(
+                        A64BackendContext, pending_stackpoint_sync_node))));
+  auto& bad = NewCachedLabel();
 
-  // w13 = target depth computed by ResolveFunction.
-  ldr(w13, ptr(x19, static_cast<uint32_t>(offsetof(
-                        A64BackendContext, pending_stackpoint_sync_depth))));
-  auto& underflow = NewCachedLabel();
+  // A null target means this helper was called without a pending repair.
+  cbz(x10, bad);
+  // Nodes live at frame_base + STACKPOINT_PREV of a 16-aligned frame, so a
+  // valid pointer is always 8 mod 16.
+  and_(x11, x10, 0xF);
+  cmp(x11, 8);
+  b(NE, bad);
+  // A repair target is always an older (higher-addressed) frame; a node at
+  // or below live SP is corrupt.
+  mov(x11, sp);
+  cmp(x10, x11);
+  b(LS, bad);
 
-  cbz(x10, underflow);
-  // A zero target means this helper was called without a pending repair.
-  cbz(w13, underflow);
-  // The pending target must not be deeper than the current live depth.
-  cmp(w13, w11);
-  b(HI, underflow);
+  // Publish head first, then move SP: between the two, head points above
+  // live SP, which an async signal can tolerate; the reverse order would
+  // leave head referencing memory below SP.
+  str(x10, ptr(x19, static_cast<uint32_t>(
+                        offsetof(A64BackendContext, stackpoint_head))));
+  str(xzr, ptr(x19, static_cast<uint32_t>(offsetof(
+                        A64BackendContext, pending_stackpoint_sync_node))));
 
-  // x14 = &stackpoints[target_depth - 1]
-  sub(w13, w13, 1);
-
-  mov(w14, static_cast<uint32_t>(sizeof(A64BackendStackpoint)));
-  umull(x14, w13, w14);
-  add(x14, x10, x14);
-
-  // Restore host SP from stackpoints[index].host_stack_. A64 stackpoints are
-  // recorded after the function frame allocation, so this is already the SP
-  // expected by the return-site code.
-  ldr(x16, ptr(x14, static_cast<uint32_t>(
-                        offsetof(A64BackendStackpoint, host_stack_))));
-  mov(sp, x16);
-
-  // Update current_stackpoint_depth = index + 1
-  // (the entry we restored to has been consumed)
-  add(w13, w13, 1);
-  str(w13, ptr(x19, static_cast<uint32_t>(offsetof(A64BackendContext,
-                                                   current_stackpoint_depth))));
-  mov(w15, 0);
-  str(w15, ptr(x19, static_cast<uint32_t>(offsetof(
-                        A64BackendContext, pending_stackpoint_sync_depth))));
+  // The node sits inside its frame at STACKPOINT_PREV, so the frame's
+  // post-alloc SP - which is what the return-site code expects - is the
+  // node address minus that offset.
+  sub(x12, x10, static_cast<uint32_t>(StackLayout::STACKPOINT_PREV));
+  mov(sp, x12);
 
   // Jump back to the caller.
   br(x8);
 
-  L(underflow);
-  // Should be impossible — stackpoint array underflowed.
+  L(bad);
   brk(0xF001);  // assertion failure
 
   code_offsets.epilog = getSize();
   code_offsets.tail = getSize();
 
-  EmitFunctionInfo func_info = {};
-  func_info.code_size.total = getSize();
-  func_info.code_size.prolog = code_offsets.body - code_offsets.prolog;
-  func_info.code_size.body = code_offsets.epilog - code_offsets.body;
-  func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
-  func_info.code_size.tail = getSize() - code_offsets.tail;
-  func_info.prolog_stack_alloc_offset =
-      code_offsets.prolog_stack_alloc - code_offsets.prolog;
-  func_info.stack_size = 0;
-
-  return Emplace(func_info);
+  return EmplaceHelper(code_offsets, 0);
 }
 
 // --------------------------------------------------------------------------
@@ -505,13 +538,7 @@ void* A64HelperEmitter::EmitGuestAndHostSynchronizeStackHelper() {
 // without EmitGuestToHostThunk's 28-register spill.
 void* A64HelperEmitter::EmitVRsqrtefpHelper(void** out_vector_entry) {
   using namespace Xbyak_aarch64;
-  struct {
-    size_t prolog;
-    size_t prolog_stack_alloc;
-    size_t body;
-    size_t epilog;
-    size_t tail;
-  } code_offsets = {};
+  CodeOffsets code_offsets = {};
 
   Label interpolate_setup, slow, exp_nonzero, check_negative;
   Label signed_inf, quiet_nan, ret_qnan, oddball, table;
@@ -656,17 +683,7 @@ void* A64HelperEmitter::EmitVRsqrtefpHelper(void** out_vector_entry) {
   code_offsets.epilog = getSize();
   code_offsets.tail = getSize();
 
-  EmitFunctionInfo func_info = {};
-  func_info.code_size.total = getSize();
-  func_info.code_size.prolog = code_offsets.body - code_offsets.prolog;
-  func_info.code_size.body = code_offsets.epilog - code_offsets.body;
-  func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
-  func_info.code_size.tail = getSize() - code_offsets.tail;
-  func_info.prolog_stack_alloc_offset =
-      code_offsets.prolog_stack_alloc - code_offsets.prolog;
-  func_info.stack_size = 0;
-
-  void* fn = Emplace(func_info);
+  void* fn = EmplaceHelper(code_offsets, 0);
   *out_vector_entry = static_cast<uint8_t*>(fn) + vector_entry_offset;
   return fn;
 }
@@ -678,13 +695,7 @@ void* A64HelperEmitter::EmitVRsqrtefpHelper(void** out_vector_entry) {
 // so it needs no guest->host thunk.
 void* A64HelperEmitter::EmitFrsqrteHelper() {
   using namespace Xbyak_aarch64;
-  struct {
-    size_t prolog;
-    size_t prolog_stack_alloc;
-    size_t body;
-    size_t epilog;
-    size_t tail;
-  } code_offsets = {};
+  CodeOffsets code_offsets = {};
 
   Label exp_nonmax, check_negative, compute;
   Label signed_inf, quiet_nan, ret_qnan, table;
@@ -762,17 +773,7 @@ void* A64HelperEmitter::EmitFrsqrteHelper() {
   code_offsets.epilog = getSize();
   code_offsets.tail = getSize();
 
-  EmitFunctionInfo func_info = {};
-  func_info.code_size.total = getSize();
-  func_info.code_size.prolog = code_offsets.body - code_offsets.prolog;
-  func_info.code_size.body = code_offsets.epilog - code_offsets.body;
-  func_info.code_size.epilog = code_offsets.tail - code_offsets.epilog;
-  func_info.code_size.tail = getSize() - code_offsets.tail;
-  func_info.prolog_stack_alloc_offset =
-      code_offsets.prolog_stack_alloc - code_offsets.prolog;
-  func_info.stack_size = 0;
-
-  return Emplace(func_info);
+  return EmplaceHelper(code_offsets, 0);
 }
 
 // ==========================================================================
@@ -899,9 +900,8 @@ uint64_t ResolveFunction(void* raw_context, uint64_t target_address) {
       target_address <= 0xFFFFFFFFu) {
     auto* module_for_address =
         processor->LookupModule(static_cast<uint32_t>(target_address));
-    auto* xexmod = dynamic_cast<XexModule*>(module_for_address);
-    if (xexmod) {
-      InfoCacheFlags* flags = xexmod->GetInstructionAddressFlags(
+    if (module_for_address) {
+      InfoCacheFlags* flags = module_for_address->GetInstructionAddressFlags(
           static_cast<uint32_t>(target_address));
       if (flags && flags->is_return_site) {
         uintptr_t host_address = 0;
@@ -916,12 +916,11 @@ uint64_t ResolveFunction(void* raw_context, uint64_t target_address) {
             auto* backend = static_cast<A64Backend*>(processor->backend());
             auto* backend_context =
                 backend->BackendContextForGuestContext(guest_context);
-            const uint32_t sync_depth = FindStackpointSyncDepth(
-                backend_context->stackpoints,
-                backend_context->current_stackpoint_depth,
+            const A64StackpointNode* sync_node = FindStackpointSyncNode(
+                backend_context->stackpoint_head,
                 static_cast<uint32_t>(guest_context->r[1]));
-            if (sync_depth != 0) {
-              backend_context->pending_stackpoint_sync_depth = sync_depth;
+            if (sync_node) {
+              backend_context->pending_stackpoint_sync_node = sync_node;
               return host_address;
             }
             break;
@@ -1076,6 +1075,7 @@ bool A64Backend::Initialize(Processor* processor) {
 
   host_to_guest_thunk_ = thunk_emitter.EmitHostToGuestThunk();
   guest_to_host_thunk_ = thunk_emitter.EmitGuestToHostThunk();
+  guest_to_host_thunk_no_vec_ = thunk_emitter.EmitGuestToHostThunkNoVec();
   resolve_function_thunk_ = thunk_emitter.EmitResolveFunctionThunk();
 
   if (!host_to_guest_thunk_ || !guest_to_host_thunk_ ||
@@ -1191,6 +1191,18 @@ void A64Backend::InitializeBackendContext(void* ctx) {
   a64_ctx->fpcr_vmx_daz = DEFAULT_VMX_FPCR;   // never follows NJM
   a64_ctx->flags = (1U << kA64BackendNJMOn);  // NJM on by default
   a64_ctx->guest_tick_count = Clock::GetGuestTickCountPointer();
+  // CALL_INDIRECT's encoded mode reads these from x19; see A64BackendContext.
+  auto* cache = static_cast<A64CodeCache*>(code_cache_.get());
+  a64_ctx->indirection_table_bias = cache->indirection_table_base_bias();
+  a64_ctx->code_execute_base = cache->execute_base_address();
+  a64_ctx->external_indirection_table =
+      cache->external_indirection_table_base_address();
+  assert_not_null(guest_to_host_thunk_);
+  a64_ctx->guest_to_host_thunk_address =
+      reinterpret_cast<uint64_t>(guest_to_host_thunk_);
+  assert_not_null(guest_to_host_thunk_no_vec_);
+  a64_ctx->guest_to_host_thunk_no_vec_address =
+      reinterpret_cast<uint64_t>(guest_to_host_thunk_no_vec_);
 
   auto set_est = [&](int index, float value) {
     uint32_t bits;
@@ -1231,31 +1243,23 @@ void A64Backend::InitializeBackendContext(void* ctx) {
   set_est_bits(kEstMantissaMask, 0x007FFFFFu);
   set_est_bits(kEstQuietBit, 0x00400000u);
 
-  // Allocate stackpoints for longjmp detection.
-  if (cvars::a64_enable_host_guest_stack_synchronization) {
-    uint64_t max_stackpoints = cvars::a64_max_stackpoints;
-    if (max_stackpoints > 0) {
-      a64_ctx->stackpoints = new A64BackendStackpoint[max_stackpoints]();
-    }
-  }
+  // Longjmp detection state: nodes live in the guest frames themselves, so
+  // the context only carries the chain head and the pending repair marker.
+  a64_ctx->stackpoint_head = nullptr;
+  a64_ctx->pending_stackpoint_sync_node = nullptr;
 
   // Reset the live host FPCR for a fresh PPC context so one test's rounding
   // state does not leak into the next on the shared PPC test runner thread.
   SetGuestRoundingMode(ctx, 0);
 }
 
-void A64Backend::DeinitializeBackendContext(void* ctx) {
-  auto* a64_ctx = BackendContextForGuestContext(ctx);
-  if (a64_ctx->stackpoints) {
-    delete[] a64_ctx->stackpoints;
-    a64_ctx->stackpoints = nullptr;
-  }
-}
+void A64Backend::DeinitializeBackendContext(void* ctx) {}
 
 void A64Backend::PrepareForReentry(void* ctx) {
   auto* a64_ctx = BackendContextForGuestContext(ctx);
-  a64_ctx->current_stackpoint_depth = 0;
-  a64_ctx->pending_stackpoint_sync_depth = 0;
+  // The old frames' nodes die with the host stack unwind; drop the chain.
+  a64_ctx->stackpoint_head = nullptr;
+  a64_ctx->pending_stackpoint_sync_node = nullptr;
 }
 
 uint32_t A64Backend::CreateGuestTrampoline(GuestTrampolineProc proc,
@@ -1375,24 +1379,21 @@ bool A64Backend::PopulatePseudoStacktrace(GuestPseudoStackTrace* st) {
   ppc::PPCContext* ctx = thrd_state->context();
   A64BackendContext* backend_ctx = BackendContextForGuestContext(ctx);
 
-  if (!backend_ctx->stackpoints || backend_ctx->current_stackpoint_depth < 2) {
+  // Walk the frame-embedded chain newest-first. The root node (the frame
+  // entered from the host thunk) is not reported, and the entry cap bounds
+  // the walk. Same-thread only: these are the calling thread's own live host
+  // frames.
+  const A64StackpointNode* node = backend_ctx->stackpoint_head;
+  if (!node || !node->prev_) {
     return false;
   }
-  uint32_t depth = backend_ctx->current_stackpoint_depth - 1;
-  uint32_t num_entries_to_populate =
-      std::min(MAX_GUEST_PSEUDO_STACKTRACE_ENTRIES, depth);
-
-  st->count = num_entries_to_populate;
-  st->truncated_flag = num_entries_to_populate < depth ? 1 : 0;
-
-  A64BackendStackpoint* current_stackpoint =
-      &backend_ctx->stackpoints[backend_ctx->current_stackpoint_depth - 1];
-
-  for (uint32_t stp_index = 0; stp_index < num_entries_to_populate;
-       ++stp_index) {
-    st->return_addrs[stp_index] = current_stackpoint->guest_return_address_;
-    current_stackpoint--;
+  uint32_t n = 0;
+  while (node && node->prev_ && n < MAX_GUEST_PSEUDO_STACKTRACE_ENTRIES) {
+    st->return_addrs[n++] = node->guest_return_address_;
+    node = node->prev_;
   }
+  st->count = n;
+  st->truncated_flag = (node && node->prev_) ? 1 : 0;
   return true;
 }
 

--- a/src/xenia/cpu/backend/a64/a64_backend.h
+++ b/src/xenia/cpu/backend/a64/a64_backend.h
@@ -58,14 +58,23 @@ struct ReserveHelper {
   }
 };
 
-struct A64BackendStackpoint {
-  uint64_t host_stack_;
-  unsigned guest_stack_;
-  unsigned guest_return_address_;
+// One record per live guest frame, embedded in that frame's host stack at
+// StackLayout::STACKPOINT_PREV and linked through stackpoint_head. The
+// record's own address identifies the frame: address - STACKPOINT_PREV is
+// the frame's post-alloc SP.
+struct A64StackpointNode {
+  const A64StackpointNode* prev_;  // older frame's node, null at chain root
+  uint32_t guest_stack_;           // guest r1 at function entry
+  uint32_t guest_return_address_;  // guest lr at function entry
 };
+static_assert(sizeof(A64StackpointNode) == 16,
+              "the push emission pairs prev_ with the ret-slot zeroing and "
+              "the two guest words with one stp");
 
-uint32_t FindStackpointSyncDepth(const A64BackendStackpoint* stackpoints,
-                                 uint32_t current_depth, uint32_t guest_sp);
+// Walks the chain looking for a longjmp: more than one live frame skipped
+// by |guest_sp|. Returns the node to restore, or null (no repair).
+const A64StackpointNode* FindStackpointSyncNode(const A64StackpointNode* head,
+                                                uint32_t guest_sp);
 
 enum : uint32_t {
   kA64BackendFPCRModeBit = 0,
@@ -108,12 +117,22 @@ struct A64BackendContext {
   ReserveHelper* reserve_helper_;
   uint64_t cached_reserve_value_;
   uint64_t* guest_tick_count;
-  A64BackendStackpoint* stackpoints;
+  // Constants for CALL_INDIRECT's encoded indirection mode; a call site
+  // loads each with one ldr from x19. Stable after code-cache Initialize.
+  uint64_t indirection_table_bias;
+  uint64_t code_execute_base;
+  uint64_t external_indirection_table;
+  // The guest-to-host thunk's address, loaded the same way by CallNativeSafe
+  // and the preempt yield. Stable once Initialize emits the thunk.
+  uint64_t guest_to_host_thunk_address;
+  // Same thunk without the vector save/restore, for transitions where
+  // no HIR value can be live in q4-q31. See EmitGuestToHostThunkNoVec.
+  uint64_t guest_to_host_thunk_no_vec_address;
+  const A64StackpointNode* stackpoint_head;
   // address of the live reservation, and its granule generation when taken
   uint32_t reserve_address;
   uint32_t reserve_generation;
-  unsigned int current_stackpoint_depth;
-  unsigned int pending_stackpoint_sync_depth;
+  const A64StackpointNode* pending_stackpoint_sync_node;
   unsigned int fpcr_fpu;
   unsigned int fpcr_vmx;
   // bit 0 = 0 if fpcr is fpu, else it is vmx
@@ -128,6 +147,12 @@ struct A64BackendContext {
 constexpr unsigned int DEFAULT_FPU_FPCR = 0;
 // Default FPCR for VMX mode (flush to zero, preserve NaN payloads).
 constexpr unsigned int DEFAULT_VMX_FPCR = (1 << 24);  // FZ
+// Invariant: FPCR.DN is clear in every FPCR image this backend installs
+// (these defaults, SET_ROUNDING_MODE's fpcr_table, SET_NJM's FZ toggle).
+// With DN clear a NaN operand propagates its payload and an invalid
+// operation with no NaN operand produces the default QNaN (0x7FC00000 /
+// 0x7FF8000000000000), which is also PPC's default QNaN. The scalar and
+// vector NaN fixups in a64_sequences.cc and a64_seq_util.h rely on both.
 
 class A64Backend : public Backend {
  public:
@@ -143,6 +168,9 @@ class A64Backend : public Backend {
 
   HostToGuestThunk host_to_guest_thunk() const { return host_to_guest_thunk_; }
   GuestToHostThunk guest_to_host_thunk() const { return guest_to_host_thunk_; }
+  GuestToHostThunk guest_to_host_thunk_no_vec() const {
+    return guest_to_host_thunk_no_vec_;
+  }
   ResolveFunctionThunk resolve_function_thunk() const {
     return resolve_function_thunk_;
   }
@@ -214,6 +242,7 @@ class A64Backend : public Backend {
 
   HostToGuestThunk host_to_guest_thunk_ = nullptr;
   GuestToHostThunk guest_to_host_thunk_ = nullptr;
+  GuestToHostThunk guest_to_host_thunk_no_vec_ = nullptr;
   ResolveFunctionThunk resolve_function_thunk_ = nullptr;
   void* synchronize_guest_and_host_stack_helper_ = nullptr;
   void* vrsqrtefp_scalar_helper_ = nullptr;

--- a/src/xenia/cpu/backend/a64/a64_code_cache_win.cc
+++ b/src/xenia/cpu/backend/a64/a64_code_cache_win.cc
@@ -151,13 +151,12 @@ static size_t BuildThunkUnwindCodes(uint8_t* buf) {
 }
 
 // Build minimal unwind codes for a guest function prolog.
-// Guest functions only do: sub sp, sp, #N; str x30, [sp, #64]
+// Guest functions only do: sub sp, sp, #N; stp x0, x30, [sp, #48]
 // The callee-saved registers were already saved by the thunk.
 static size_t BuildGuestUnwindCodes(uint8_t* buf, uint32_t stack_size) {
   size_t off = 0;
-  // The guest function stores x30 at [sp + HOST_RET_ADDR] via STR, not STP.
-  // Windows unwinder needs to know where LR is to unwind. We encode this as
-  // save_lrpair — but there's no single-register LR save opcode on ARM64.
+  // The guest function stores x0/x30 at [sp + GUEST_RET_ADDR] with an
+  // unpaired-with-FP stp the unwind opcodes cannot describe directly.
   // Instead we describe the stack allocation only. The host return address
   // is stored by the JIT but is not a callee-save operation (it's the thunk's
   // LR, not the guest function's). The unwinder will walk up to the thunk

--- a/src/xenia/cpu/backend/a64/a64_emitter.cc
+++ b/src/xenia/cpu/backend/a64/a64_emitter.cc
@@ -27,7 +27,6 @@
 #include "xenia/cpu/ppc/ppc_context.h"
 #include "xenia/cpu/processor.h"
 
-DECLARE_int64(a64_max_stackpoints);
 DECLARE_bool(a64_enable_host_guest_stack_synchronization);
 
 DECLARE_bool(log_safepoint_pc);
@@ -102,7 +101,12 @@ bool A64Emitter::Emit(GuestFunction* function, hir::HIRBuilder* builder,
   source_map_arena_.Reset();
   tail_code_.clear();
   label_bind_offsets_.clear();
-  fpcr_mode_ = FPCRMode::Unknown;
+  // Every path into a guest function runs in the scalar FPU mode (see the
+  // FPCR tracking contract in a64_emitter.h). The pre-scan records that
+  // entry edge on the first block, so a function whose first block is not a
+  // loop header starts Known-Fpu and skips both the first
+  // ChangeFpcrMode(Fpu) msr and the exit transition guard.
+  fpcr_mode_ = FPCRMode::Fpu;
 
   // The prolog, epilog and helpers emit outside the per-opcode guard below, so
   // an unencodable operand needs catching here too.
@@ -138,6 +142,94 @@ bool A64Emitter::Emit(GuestFunction* function, hir::HIRBuilder* builder,
 }
 
 bool A64Emitter::Emit(hir::HIRBuilder* builder, EmitFunctionInfo& func_info) {
+  // Decide up front whether single-instruction branches to tail labels are
+  // safe; the prolog's stackpoint check needs the answer too. cbnz/b.cond
+  // reach +/-1 MiB and the distance to a tail is bounded by the rest of the
+  // body plus every tail block plus the literal-pool islands that
+  // MaybeFlushV128ConstPool emits at block ends and between tails. All of
+  // that is counted against 256 bytes per HIR instruction: the budget is far
+  // above the fattest sequence this backend emits, and every pool entry (16
+  // bytes) is referenced by at least one instruction of a sequence, so a
+  // function passing this test cannot place any tail out of range. Functions
+  // failing it (which would need ~3000+ HIR instructions) keep the expanded
+  // far form.
+  function_has_vmx_ = false;
+  expected_preds_.clear();
+  incoming_fpcr_.clear();
+  label_block_.clear();
+  {
+    // Labels resolve to blocks through each block's own label chain - the
+    // same mapping the emitter binds branch targets from. A label's ->block
+    // back-pointer can be stale after the passes reshape blocks, exactly like
+    // the edges ControlFlowAnalysisPass recorded (which also never included
+    // fall-through), so neither is trusted here.
+    auto& label_block = label_block_;
+    for (auto* b = builder->first_block(); b; b = b->next) {
+      for (auto* label = b->label_head; label; label = label->next) {
+        label_block[label] = b;
+      }
+    }
+    size_t hir_instr_count = 0;
+    for (auto* b = builder->first_block(); b; b = b->next) {
+      // Expected predecessor count, recomputed from the final HIR. Branches
+      // can sit MID-block (the not-taken path continues inside the same
+      // block), so every instruction is scanned, not just the tail - the
+      // edges ControlFlowAnalysisPass recorded are both stale and
+      // tail-only.
+      for (auto* i = b->instr_head; i; i = i->next) {
+        const hir::Label* label = nullptr;
+        if (i->opcode == &hir::OPCODE_BRANCH_info) {
+          label = i->src1.label;
+        } else if (i->opcode == &hir::OPCODE_BRANCH_TRUE_info ||
+                   i->opcode == &hir::OPCODE_BRANCH_FALSE_info) {
+          label = i->src2.label;
+        }
+        if (label) {
+          auto it = label_block.find(label);
+          if (it != label_block.end()) {
+            ++expected_preds_[it->second];
+          }
+        }
+      }
+      // Fall-through exists unless the block's final instruction is an
+      // unconditional branch. A block ending in RETURN or a tail
+      // CALL_INDIRECT also counts one here, and the emit loop records the
+      // matching edge for it, so the two sides always agree.
+      auto* last = b->instr_tail;
+      if (b->next && !(last && last->opcode == &hir::OPCODE_BRANCH_info)) {
+        ++expected_preds_[b->next];
+      }
+      for (auto* i = b->instr_head; i; i = i->next) {
+        ++hir_instr_count;
+        if (i->dest && i->dest->type == hir::VEC128_TYPE) {
+          function_has_vmx_ = true;
+        } else if (!function_has_vmx_) {
+          uint32_t sig = i->opcode->signature;
+          const hir::Instr::Op* ops[3] = {&i->src1, &i->src2, &i->src3};
+          for (int k = 0; k < 3; ++k) {
+            auto t = static_cast<hir::OpcodeSignatureType>(
+                (sig >> (3 * (k + 1))) & 0x7);
+            if (t == hir::OPCODE_SIG_TYPE_V &&
+                ops[k]->value->type == hir::VEC128_TYPE) {
+              function_has_vmx_ = true;
+              break;
+            }
+          }
+        }
+      }
+    }
+    // The function entry is a predecessor edge of the first block like any
+    // other: it contributes Fpu (the entry contract) and counts toward the
+    // block's expected total. A first block that is also a loop header
+    // therefore has one more expected edge than has been recorded when it
+    // is emitted and starts Unknown, exactly like any other loop header.
+    ++expected_preds_[builder->first_block()];
+    RecordIncomingFpcr(builder->first_block(), FPCRMode::Fpu);
+    near_tail_branches_safe_ = hir_instr_count * 256 < (768 * 1024);
+    // tbnz reaches only +/-32 KiB, so its tail form needs a tighter bound.
+    near_tbz_branches_safe_ = hir_instr_count * 256 < (24 * 1024);
+  }
+
   // Calculate local variable stack offsets.
   auto locals = builder->locals();
   size_t stack_offset = StackLayout::GUEST_STACK_SIZE;
@@ -183,14 +275,15 @@ bool A64Emitter::Emit(hir::HIRBuilder* builder, EmitFunctionInfo& func_info) {
   }
   code_offsets.prolog_stack_alloc = getSize();
 
-  // Store host return address (x30/LR) so the epilog can restore it.
-  str(x30, ptr(sp, static_cast<uint32_t>(StackLayout::HOST_RET_ADDR)));
-  // Store guest PPC return address (passed in x0 by convention).
-  str(x0, ptr(sp, static_cast<uint32_t>(StackLayout::GUEST_RET_ADDR)));
-  // Store zero for call return address (we haven't made a call yet).
-  str(xzr, ptr(sp, static_cast<uint32_t>(StackLayout::GUEST_CALL_RET_ADDR)));
+  // Store the guest PPC return address (passed in x0 by convention) and the
+  // host return address (x30/LR) with one paired store; the layout keeps the
+  // two slots adjacent for exactly this.
+  static_assert(StackLayout::HOST_RET_ADDR == StackLayout::GUEST_RET_ADDR + 8);
+  stp(x0, x30, ptr(sp, static_cast<int32_t>(StackLayout::GUEST_RET_ADDR)));
 
-  // Record stackpoint for longjmp recovery.
+  // Record stackpoint for longjmp recovery. Also zeroes the call-return slot
+  // (no call made yet), paired with the entry-depth spill when the
+  // synchronizer is on.
   PushStackpoint();
 
   // ========================================================================
@@ -214,9 +307,25 @@ bool A64Emitter::Emit(hir::HIRBuilder* builder, EmitFunctionInfo& func_info) {
   auto block = builder->first_block();
   synchronize_stack_on_next_instruction_ = false;
   while (block) {
-    // Reset FPCR tracking on each block entry (we don't know which
-    // predecessor ran, so mode is unknown).
-    ForgetFpcrMode();
+    // Block-entry FPCR mode: the meet of the modes recorded on the block's
+    // incoming edges (each branch emission records the tracker's mode at the
+    // branch point, block ends record the fall-through mode, and the
+    // function entry records Fpu for the first block), used only when every
+    // expected edge has been recorded. An edge that has not been emitted
+    // yet - a loop back edge - leaves the count short, so a loop header
+    // starts Unknown. See the FPCR tracking contract in a64_emitter.h.
+    {
+      FPCRMode incoming = FPCRMode::Unknown;
+      auto exp_it = expected_preds_.find(block);
+      auto in_it = incoming_fpcr_.find(block);
+      if (exp_it != expected_preds_.end() && in_it != incoming_fpcr_.end() &&
+          in_it->second.count == exp_it->second) {
+        incoming = in_it->second.meet;
+      }
+      fpcr_mode_ = incoming;
+    }
+    // Flags from a previous block cannot be trusted either.
+    ResetFlagsZeroTest();
 
     // Bind all labels targeting this block.
     auto label = block->label_head;
@@ -232,15 +341,42 @@ bool A64Emitter::Emit(hir::HIRBuilder* builder, EmitFunctionInfo& func_info) {
       // Skip SOURCE_OFFSET because the return address from the call would
       // point past the check, so it would never execute.
       if (synchronize_stack_on_next_instruction_) {
-        if (instr->GetOpcodeNum() != hir::OPCODE_SOURCE_OFFSET) {
+        // Skip annotations as well as SOURCE_OFFSET: under full debug info
+        // the frontend emits COMMENT first, and a check emitted there sits
+        // before the recorded source-map offset, so a longjmp repair would
+        // land past it and it would never run.
+        if (instr->GetOpcodeNum() != hir::OPCODE_SOURCE_OFFSET &&
+            instr->GetOpcodeNum() != hir::OPCODE_COMMENT) {
           synchronize_stack_on_next_instruction_ = false;
           EnsureSynchronizedGuestAndHostStack();
+          // The helper call clobbers NZCV.
+          ResetFlagsZeroTest();
         }
       }
       const hir::Instr* new_tail = instr;
       bool selected = false;
       try {
         selected = SelectSequence(this, instr, &new_tail);
+        // One-shot handoff: whatever this sequence declared about NZCV is
+        // visible to exactly the next sequence and nothing later.
+        ShiftFlagsZeroTest();
+        // Record the FPCR mode this branch carries to its target (branches
+        // can sit mid-block; the mode here is the mode the jump takes).
+        {
+          const hir::Label* label = nullptr;
+          if (instr->opcode == &hir::OPCODE_BRANCH_info) {
+            label = instr->src1.label;
+          } else if (instr->opcode == &hir::OPCODE_BRANCH_TRUE_info ||
+                     instr->opcode == &hir::OPCODE_BRANCH_FALSE_info) {
+            label = instr->src2.label;
+          }
+          if (label) {
+            auto it = label_block_.find(label);
+            if (it != label_block_.end()) {
+              RecordIncomingFpcr(it->second, fpcr_mode_);
+            }
+          }
+        }
       } catch (const Xbyak_aarch64::Error& e) {
         // Uncaught this aborts the process with no context, so name the opcode
         // and the guest function and fail just this compile.
@@ -265,6 +401,14 @@ bool A64Emitter::Emit(hir::HIRBuilder* builder, EmitFunctionInfo& func_info) {
       return false;
     }
 
+    // Fall-through edge to the next block, unless this block cannot fall
+    // through.
+    {
+      auto* last = block->instr_tail;
+      if (block->next && !(last && last->opcode == &hir::OPCODE_BRANCH_info)) {
+        RecordIncomingFpcr(block->next, fpcr_mode_);
+      }
+    }
     block = block->next;
   }
 
@@ -558,9 +702,65 @@ void A64Emitter::UnimplementedInstr(const hir::Instr* i) {
   DebugBreak();
 }
 
+// Encoded indirection mode: see A64CodeCache for the entry format. Reads the
+// guest address from w16 and leaves the host target in x9; clobbers x14/x15.
+// The three constants live in the backend context, one ldr each. External
+// targets (host thunks and trampolines) number in the dozens per title, so
+// that case is cold and goes in the tail whenever tbnz's +/-32 KiB reach is
+// provable; otherwise it stays inline behind a branch-over.
+void A64Emitter::EmitEncodedIndirectionLookup() {
+  static_assert(offsetof(A64BackendContext, indirection_table_bias) < 4096 &&
+                offsetof(A64BackendContext, external_indirection_table) < 4096);
+  ldr(x14, ptr(x19, static_cast<uint32_t>(
+                        offsetof(A64BackendContext, indirection_table_bias))));
+  add(x14, x14, w16, UXTW);
+  ldr(w9, ptr(x14, static_cast<uint32_t>(0)));
+
+  if (near_tbz_branches_safe_) {
+    auto& indirection_ready = NewCachedLabel();
+    auto& external_target = AddToTail([&indirection_ready](A64Emitter& e,
+                                                           Label&) {
+      e.and_(e.w15, e.w9, A64CodeCache::kIndirectionExternalIndexMask);
+      e.ldr(e.x14,
+            ptr(e.x19, static_cast<uint32_t>(offsetof(
+                           A64BackendContext, external_indirection_table))));
+      e.add(e.x14, e.x14, e.x15, LSL, 3);
+      e.ldr(e.x9, ptr(e.x14, static_cast<uint32_t>(0)));
+      e.b(indirection_ready);
+    });
+    tbnz_near(w9, 31, external_target);
+
+    // Internal: rel32 from code cache base.
+    ldr(x14, ptr(x19, static_cast<uint32_t>(
+                          offsetof(A64BackendContext, code_execute_base))));
+    add(x9, x14, w9, UXTW);
+    L(indirection_ready);
+  } else {
+    Label external_target;
+    Label indirection_ready;
+    tbnz(w9, 31, external_target);
+
+    // Internal: rel32 from code cache base.
+    ldr(x14, ptr(x19, static_cast<uint32_t>(
+                          offsetof(A64BackendContext, code_execute_base))));
+    add(x9, x14, w9, UXTW);
+    b(indirection_ready);
+
+    // External: tagged index into the side table.
+    L(external_target);
+    and_(w15, w9, A64CodeCache::kIndirectionExternalIndexMask);
+    ldr(x14, ptr(x19, static_cast<uint32_t>(offsetof(
+                          A64BackendContext, external_indirection_table))));
+    add(x14, x14, x15, LSL, 3);
+    ldr(x9, ptr(x14, static_cast<uint32_t>(0)));
+
+    L(indirection_ready);
+  }
+}
+
 void A64Emitter::Call(const hir::Instr* instr, GuestFunction* function) {
   assert_not_null(function);
-  ForgetFpcrMode();
+  EnsureFpuFpcrModeForTransition();
   if (TryInlinePPCGprLrSaveRestore(instr, function)) {
     return;
   }
@@ -578,8 +778,7 @@ void A64Emitter::Call(const hir::Instr* instr, GuestFunction* function) {
     } else {
       // Tail call: pass our return address to the callee.
       PopStackpoint();
-      ldr(x0, ptr(sp, static_cast<uint32_t>(StackLayout::GUEST_RET_ADDR)));
-      ldr(x30, ptr(sp, static_cast<uint32_t>(StackLayout::HOST_RET_ADDR)));
+      ldp(x0, x30, ptr(sp, static_cast<int32_t>(StackLayout::GUEST_RET_ADDR)));
       if (stack_size() <= 4095) {
         add(sp, sp, static_cast<uint32_t>(stack_size()));
       } else {
@@ -599,29 +798,7 @@ void A64Emitter::Call(const hir::Instr* instr, GuestFunction* function) {
       // 32-bit host target.
       ldr(w9, ptr(x16, static_cast<uint32_t>(0)));
     } else {
-      // Encoded path: see A64CodeCache for the entry format.
-      Label external_target;
-      Label indirection_ready;
-
-      mov(x14, code_cache_->indirection_table_base_bias());
-      add(x14, x14, w16, UXTW);
-      ldr(w9, ptr(x14, static_cast<uint32_t>(0)));
-      tbnz(w9, 31, external_target);
-
-      // Internal: rel32 from code cache base.
-      mov(x14, code_cache_->execute_base_address());
-      add(x9, x14, w9, UXTW);
-      b(indirection_ready);
-
-      // External: tagged index into the side table.
-      L(external_target);
-      and_(w15, w9, A64CodeCache::kIndirectionExternalIndexMask);
-      mov(x14, code_cache_->external_indirection_table_base_address());
-      lsl(x15, x15, 3);
-      add(x14, x14, x15);
-      ldr(x9, ptr(x14, static_cast<uint32_t>(0)));
-
-      L(indirection_ready);
+      EmitEncodedIndirectionLookup();
     }
   } else {
     // No indirection table: resolve at runtime.
@@ -634,8 +811,7 @@ void A64Emitter::Call(const hir::Instr* instr, GuestFunction* function) {
 
   if (instr->flags & hir::CALL_TAIL) {
     PopStackpoint();
-    ldr(x0, ptr(sp, static_cast<uint32_t>(StackLayout::GUEST_RET_ADDR)));
-    ldr(x30, ptr(sp, static_cast<uint32_t>(StackLayout::HOST_RET_ADDR)));
+    ldp(x0, x30, ptr(sp, static_cast<int32_t>(StackLayout::GUEST_RET_ADDR)));
     if (stack_size() <= 4095) {
       add(sp, sp, static_cast<uint32_t>(stack_size()));
     } else {
@@ -716,21 +892,47 @@ bool A64Emitter::TryInlinePPCGprLrSaveRestore(const hir::Instr* instr,
   // indirection lookup and, for a tail call, the stack teardown and jump.
   ldr(w15, ptr(sp, static_cast<uint32_t>(StackLayout::GUEST_RET_ADDR)));
   cmp(w16, w15);
-  b(EQ, epilog_label());
+  if (near_tail_branches_safe_) {
+    // The epilog is bound at function end, inside the same +/-1 MiB bound
+    // that gates the other tail branches.
+    b_near(EQ, epilog_label());
+  } else {
+    b(EQ, epilog_label());
+  }
   CallIndirect(instr, 16);
   return true;
 }
 
 void A64Emitter::CallIndirect(const hir::Instr* instr, int reg_index) {
-  ForgetFpcrMode();
+  EnsureFpuFpcrModeForTransition();
   auto target_w = WReg(reg_index);
+
+  // A tail call through the indirection table reloads x0/x30 from the same
+  // slot pair the ret-check reads, so one ldp up front serves both: the
+  // b.eq-to-epilog path may clobber x0/x30 freely (the epilog reloads x30
+  // itself and ignores x0), and the indirection loads touch neither. The
+  // no-table fallback keeps the late reload because its resolve blr clobbers
+  // x0/x30.
+  const bool hoist_ret_slots =
+      (instr->flags & hir::CALL_TAIL) && code_cache_->has_indirection_table();
+  if (hoist_ret_slots) {
+    ldp(x0, x30, ptr(sp, static_cast<int32_t>(StackLayout::GUEST_RET_ADDR)));
+  }
 
   // Check if this is a possible return (e.g., PPC blr).
   if (instr->flags & hir::CALL_POSSIBLE_RETURN) {
     // Compare target guest address with our function's return address.
-    ldr(w0, ptr(sp, static_cast<uint32_t>(StackLayout::GUEST_RET_ADDR)));
+    if (!hoist_ret_slots) {
+      ldr(w0, ptr(sp, static_cast<uint32_t>(StackLayout::GUEST_RET_ADDR)));
+    }
     cmp(target_w, w0);
-    b(EQ, epilog_label());
+    if (near_tail_branches_safe_) {
+      // The epilog is bound at function end, inside the same +/-1 MiB bound
+      // that gates the other tail branches.
+      b_near(EQ, epilog_label());
+    } else {
+      b(EQ, epilog_label());
+    }
   }
 
   // Load host code address from indirection table.
@@ -744,29 +946,7 @@ void A64Emitter::CallIndirect(const hir::Instr* instr, int reg_index) {
       // 32-bit host target.
       ldr(w9, ptr(x16, static_cast<uint32_t>(0)));
     } else {
-      // Encoded path: see A64CodeCache for the entry format.
-      Label external_target;
-      Label indirection_ready;
-
-      mov(x14, code_cache_->indirection_table_base_bias());
-      add(x14, x14, w16, UXTW);
-      ldr(w9, ptr(x14, static_cast<uint32_t>(0)));
-      tbnz(w9, 31, external_target);
-
-      // Internal: rel32 from code cache base.
-      mov(x14, code_cache_->execute_base_address());
-      add(x9, x14, w9, UXTW);
-      b(indirection_ready);
-
-      // External: tagged index into the side table.
-      L(external_target);
-      and_(w15, w9, A64CodeCache::kIndirectionExternalIndexMask);
-      mov(x14, code_cache_->external_indirection_table_base_address());
-      lsl(x15, x15, 3);
-      add(x14, x14, x15);
-      ldr(x9, ptr(x14, static_cast<uint32_t>(0)));
-
-      L(indirection_ready);
+      EmitEncodedIndirectionLookup();
     }
   } else {
     // No indirection table: resolve at runtime.
@@ -781,8 +961,9 @@ void A64Emitter::CallIndirect(const hir::Instr* instr, int reg_index) {
   if (instr->flags & hir::CALL_TAIL) {
     // Tail call: pass our return address to the callee.
     PopStackpoint();
-    ldr(x0, ptr(sp, static_cast<uint32_t>(StackLayout::GUEST_RET_ADDR)));
-    ldr(x30, ptr(sp, static_cast<uint32_t>(StackLayout::HOST_RET_ADDR)));
+    if (!hoist_ret_slots) {
+      ldp(x0, x30, ptr(sp, static_cast<int32_t>(StackLayout::GUEST_RET_ADDR)));
+    }
     if (stack_size() <= 4095) {
       add(sp, sp, static_cast<uint32_t>(stack_size()));
     } else {
@@ -799,7 +980,7 @@ void A64Emitter::CallIndirect(const hir::Instr* instr, int reg_index) {
 }
 
 void A64Emitter::CallExtern(const hir::Instr* instr, const Function* function) {
-  ForgetFpcrMode();
+  EnsureFpuFpcrModeForTransition();
   bool undefined = true;
   if (function->behavior() == Function::Behavior::kBuiltin) {
     auto builtin_function = static_cast<const BuiltinFunction*>(function);
@@ -810,7 +991,9 @@ void A64Emitter::CallExtern(const hir::Instr* instr, const Function* function) {
       mov(x0, reinterpret_cast<uint64_t>(builtin_function->handler()));
       mov(x1, reinterpret_cast<uint64_t>(builtin_function->arg0()));
       mov(x2, reinterpret_cast<uint64_t>(builtin_function->arg1()));
-      mov(x9, reinterpret_cast<uint64_t>(backend()->guest_to_host_thunk()));
+      ldr(x9, ptr(GetBackendCtxReg(),
+                  static_cast<uint32_t>(offsetof(
+                      A64BackendContext, guest_to_host_thunk_no_vec_address))));
       blr(x9);
     }
   } else if (function->behavior() == Function::Behavior::kExtern) {
@@ -821,7 +1004,9 @@ void A64Emitter::CallExtern(const hir::Instr* instr, const Function* function) {
       mov(x0, reinterpret_cast<uint64_t>(extern_function->extern_handler()));
       ldr(x1, ptr(GetContextReg(), static_cast<int32_t>(offsetof(
                                        ppc::PPCContext, kernel_state))));
-      mov(x9, reinterpret_cast<uint64_t>(backend()->guest_to_host_thunk()));
+      ldr(x9, ptr(GetBackendCtxReg(),
+                  static_cast<uint32_t>(offsetof(
+                      A64BackendContext, guest_to_host_thunk_no_vec_address))));
       blr(x9);
     }
   }
@@ -835,11 +1020,22 @@ void A64Emitter::CallExtern(const hir::Instr* instr, const Function* function) {
 void A64Emitter::CallNative(void* fn) { CallNativeSafe(fn); }
 
 void A64Emitter::CallNativeSafe(void* fn) {
+  // The transition guard sits here, inside any inline-MMIO taken branch, so
+  // the switch executes exactly on the path that reaches the thunk. The
+  // fall-through path of such a branch keeps its entry mode, so after the
+  // call the tracker is met with the entry mode: still Fpu when nothing had
+  // to be switched, Unknown otherwise, which makes later ops re-establish
+  // the mode on both paths.
+  const FPCRMode entry_mode = fpcr_mode_;
+  EnsureFpuFpcrModeForTransition();
   // GuestToHostThunk: x0=target function, x1/x2=args (set by caller).
   // The thunk rearranges: saves x0 in x9, sets x0=context, calls x9.
   mov(x0, reinterpret_cast<uint64_t>(fn));
-  mov(x9, reinterpret_cast<uint64_t>(backend()->guest_to_host_thunk()));
+  ldr(x9, ptr(GetBackendCtxReg(),
+              static_cast<uint32_t>(
+                  offsetof(A64BackendContext, guest_to_host_thunk_address))));
   blr(x9);
+  MergeFpcrModeAfterConditional(entry_mode);
 }
 
 void A64Emitter::SetReturnAddress(uint64_t value) {
@@ -930,26 +1126,58 @@ uint32_t A64Emitter::MapReg(const hir::Value* v, const uint32_t* map, int count,
 
 void A64Emitter::EmitPreemptCheck(uint32_t guest_address) {
   // Only safe at a block head, where the per-block register allocator leaves no
-  // guest value live and ForgetFpcrMode has already run, so the unannounced
-  // guest->host call cannot lose a register or desync the mode tracking.
+  // guest value live and the block-entry seeding has just set the tracker, so
+  // the unannounced guest->host call cannot lose a register or desync the
+  // mode tracking.
   //
   // Tests the preempt flag other threads raise. The cold path clears it, a
   // deferred yield re-sets it.
+  // The yield path clobbers FPCR at runtime, but it is cold: when the
+  // tracker holds a known mode here (block-entry seeding often just
+  // established one), the yield tail restores that mode after the host
+  // call, so the hot path's static mode survives the check untouched. Only
+  // an already-unknown mode stays unknown.
   Label& after = NewCachedLabel();
   // ldrb/strb unsigned-offset encoding caps at 4095.
   static_assert(offsetof(ppc::PPCContext, preempt_requested) < 4096);
   const uint32_t flag_offset =
       static_cast<uint32_t>(offsetof(ppc::PPCContext, preempt_requested));
-  Label& do_yield = AddToTail([&after, flag_offset](A64Emitter& e, Label&) {
+  const bool has_vmx = function_has_vmx_;
+  const FPCRMode held_mode = fpcr_mode_;
+  Label& do_yield = AddToTail([&after, flag_offset, has_vmx, held_mode](
+                                  A64Emitter& e, Label&) {
+    // The yield calls host code, which must run in FPU mode. The runtime mode
+    // here is whatever the interrupted block was in - unknowable at emission
+    // - so functions that touch VEC128 switch unconditionally (cold path).
+    if (has_vmx) {
+      e.ldr(e.w0, ptr(e.x19, static_cast<uint32_t>(
+                                 offsetof(A64BackendContext, fpcr_fpu))));
+      e.msr(3, 3, 4, 4, 0, e.x0);  // msr FPCR, x0
+    }
     e.strb(e.wzr, ptr(e.x20, flag_offset));
     // Null until the scheduler starts, and a stale flag can reach here after
     // it shuts down, so check before calling.
     e.mov(e.x0,
           reinterpret_cast<uint64_t>(&xe::cpu::backend::preempt_yield_handler));
     e.ldr(e.x0, ptr(e.x0));
-    e.cbz(e.x0, after);
-    e.mov(e.x9, reinterpret_cast<uint64_t>(e.backend()->guest_to_host_thunk()));
+    const bool restore_held =
+        held_mode != FPCRMode::Unknown && held_mode != FPCRMode::Fpu;
+    Xbyak_aarch64::Label rejoin;
+    // A null handler (scheduler not yet started, or shut down with a stale
+    // flag) must still pass through the held-mode restore below: the FPU
+    // switch above already ran, and the hot path continues assuming
+    // held_mode.
+    e.cbz(e.x0, restore_held ? rejoin : after);
+    e.ldr(e.x9, ptr(e.GetBackendCtxReg(),
+                    static_cast<uint32_t>(offsetof(
+                        A64BackendContext, guest_to_host_thunk_address))));
     e.blr(e.x9);
+    // Re-establish the mode the hot path still assumes (the host call left
+    // FPCR in the scalar FPU state via the guest-to-host thunk).
+    if (restore_held) {
+      e.L(rejoin);
+      e.ReloadFpcrMode(held_mode);
+    }
     e.b(after);
   });
   if (cvars::log_safepoint_pc && guest_address) {
@@ -961,7 +1189,13 @@ void A64Emitter::EmitPreemptCheck(uint32_t guest_address) {
                          offsetof(ppc::PPCContext, last_safepoint_pc))));
   }
   ldrb(w8, ptr(x20, flag_offset));
-  cbnz(w8, do_yield);
+  if (near_tail_branches_safe_) {
+    // Not-taken fall-through: two instructions on the hot path instead of an
+    // inverted branch over an unconditional one.
+    cbnz_near(w8, do_yield);
+  } else {
+    cbnz(w8, do_yield);
+  }
   L(after);
 }
 
@@ -1037,68 +1271,43 @@ bool A64Emitter::MaybeFlushV128ConstPool() {
   return FlushV128ConstPool(true);
 }
 
-void A64Emitter::HandleStackpointOverflowError(ppc::PPCContext* context) {
-  if (debugging::IsDebuggerAttached()) {
-    debugging::Break();
-  }
-  xe::FatalError(
-      "Overflowed stackpoints! Please report this error for this title to "
-      "Xenia developers.");
-}
-
 void A64Emitter::PushStackpoint() {
   if (!cvars::a64_enable_host_guest_stack_synchronization) {
+    // Still owns zeroing the call-return slot (see the prolog).
+    str(xzr, ptr(sp, static_cast<uint32_t>(StackLayout::GUEST_CALL_RET_ADDR)));
     return;
   }
-  // x8 = stackpoints array, w9 = current depth
-  ldr(x8, ptr(x19,
-              static_cast<uint32_t>(offsetof(A64BackendContext, stackpoints))));
-  ldr(w9, ptr(x19, static_cast<uint32_t>(
-                       offsetof(A64BackendContext, current_stackpoint_depth))));
-
-  // x8 += w9 * sizeof(A64BackendStackpoint) via scaled extended-register add.
-  static_assert(sizeof(A64BackendStackpoint) == 16,
-                "stackpoint indexing relies on a 16-byte element size");
-  add(x8, x8, w9, UXTW, 4);
-
-  // Store host SP.
-  mov(x10, sp);
-  str(x10, ptr(x8, static_cast<uint32_t>(
-                       offsetof(A64BackendStackpoint, host_stack_))));
-  // Store guest r1 (32-bit).
-  ldr(w10, ptr(x20, static_cast<int32_t>(offsetof(ppc::PPCContext, r[1]))));
-  str(w10, ptr(x8, static_cast<uint32_t>(
-                       offsetof(A64BackendStackpoint, guest_stack_))));
-  // Store guest LR (32-bit).
+  // Link this frame's node into the chain. All node fields are written
+  // before the head store, so an async signal never observes a head
+  // pointing at an uninitialized node, and the node sits above live SP so
+  // signal frames cannot smash it. The chain has no depth bound: runaway
+  // recursion is stopped by the host stack guard page.
+  static_assert(StackLayout::STACKPOINT_PREV ==
+                StackLayout::GUEST_CALL_RET_ADDR + 8);
+  static_assert(StackLayout::STACKPOINT_GUEST_SP ==
+                StackLayout::STACKPOINT_PREV + 8);
+  static_assert(StackLayout::STACKPOINT_GUEST_RET ==
+                StackLayout::STACKPOINT_GUEST_SP + 4);
+  ldr(x8, ptr(x19, static_cast<uint32_t>(
+                       offsetof(A64BackendContext, stackpoint_head))));
+  ldr(w9, ptr(x20, static_cast<int32_t>(offsetof(ppc::PPCContext, r[1]))));
   ldr(w10, ptr(x20, static_cast<int32_t>(offsetof(ppc::PPCContext, lr))));
-  str(w10, ptr(x8, static_cast<uint32_t>(
-                       offsetof(A64BackendStackpoint, guest_return_address_))));
-
-  // Increment depth.
-  add(w9, w9, 1);
-  str(w9, ptr(x19, static_cast<uint32_t>(
-                       offsetof(A64BackendContext, current_stackpoint_depth))));
-
-  // Check for overflow.
-  mov(w10, static_cast<uint32_t>(cvars::a64_max_stackpoints));
-  cmp(w9, w10);
-  auto& overflow_label = AddToTail([](A64Emitter& e, Label& lbl) {
-    e.CallNativeSafe(
-        reinterpret_cast<void*>(A64Emitter::HandleStackpointOverflowError));
-  });
-  b(GE, overflow_label);
+  // Zero the call-return slot and store prev_ with one pair.
+  stp(xzr, x8, ptr(sp, static_cast<int32_t>(StackLayout::GUEST_CALL_RET_ADDR)));
+  stp(w9, w10, ptr(sp, static_cast<int32_t>(StackLayout::STACKPOINT_GUEST_SP)));
+  add(x11, sp, static_cast<uint32_t>(StackLayout::STACKPOINT_PREV));
+  str(x11, ptr(x19, static_cast<uint32_t>(
+                        offsetof(A64BackendContext, stackpoint_head))));
 }
-
 void A64Emitter::PopStackpoint() {
   if (!cvars::a64_enable_host_guest_stack_synchronization) {
     return;
   }
-  // Decrement current_stackpoint_depth.
-  ldr(w8, ptr(x19, static_cast<uint32_t>(
-                       offsetof(A64BackendContext, current_stackpoint_depth))));
-  sub(w8, w8, 1);
-  str(w8, ptr(x19, static_cast<uint32_t>(
-                       offsetof(A64BackendContext, current_stackpoint_depth))));
+  // head = this frame's prev_. Runs before the frame teardown at every pop
+  // site, so there is no window where head points below live SP.
+  ldr(x8, ptr(sp, static_cast<uint32_t>(StackLayout::STACKPOINT_PREV)));
+  str(x8, ptr(x19, static_cast<uint32_t>(
+                       offsetof(A64BackendContext, stackpoint_head))));
 }
 
 void A64Emitter::EnsureSynchronizedGuestAndHostStack() {
@@ -1110,10 +1319,10 @@ void A64Emitter::EnsureSynchronizedGuestAndHostStack() {
   // still point at a skipped frame here.
   auto& return_from_sync = NewCachedLabel();
 
-  ldr(w16, ptr(x19, static_cast<uint32_t>(offsetof(
-                        A64BackendContext, pending_stackpoint_sync_depth))));
+  ldr(x16, ptr(x19, static_cast<uint32_t>(offsetof(
+                        A64BackendContext, pending_stackpoint_sync_node))));
   // Bound forward target (adr + b below) — short form is safe.
-  cbz_near(w16, return_from_sync);
+  cbz_near(x16, return_from_sync);
 
   auto& sync_label = AddToTail([](A64Emitter& e, Label& lbl) {
     // x8 was set up in the body to point at return_from_sync; do that there

--- a/src/xenia/cpu/backend/a64/a64_emitter.h
+++ b/src/xenia/cpu/backend/a64/a64_emitter.h
@@ -109,11 +109,64 @@ class A64Emitter : public Xbyak_aarch64::CodeGenerator {
   static void SetupReg(const hir::Value* v, Xbyak_aarch64::VReg& r) {
     r = Xbyak_aarch64::VReg(MapReg(v, vec_reg_map_, VEC_COUNT, "vec"));
   }
+  // True when branches to tail labels may use the single-instruction near
+  // forms (see Emit); sequences use this to place cold paths out of line.
+  bool near_tail_branches_safe() const { return near_tail_branches_safe_; }
 
   Xbyak_aarch64::Label& epilog_label() { return *epilog_label_; }
 
   FunctionDebugInfo* debug_info() const { return debug_info_; }
   size_t stack_size() const { return stack_size_; }
+
+  // NZCV fusion between adjacent HIR instructions. The classic producer is
+  // ANDS (condition NE); a producer may instead declare any condition code
+  // that is true at runtime exactly when the register is nonzero, on every
+  // path reaching the next instruction.
+  void DeclareFlagsZeroTest(int gpr_reg, bool is64) {
+    DeclareFlagsNonzeroCond(gpr_reg, is64, Xbyak_aarch64::NE);
+  }
+  void DeclareFlagsNonzeroCond(int gpr_reg, bool is64,
+                               Xbyak_aarch64::Cond cond) {
+    flags_zero_fresh_reg_ = gpr_reg;
+    flags_zero_fresh_is64_ = is64;
+    flags_zero_fresh_cond_ = cond;
+  }
+  bool FlagsNonzeroCondHeld(int gpr_reg, bool is64,
+                            Xbyak_aarch64::Cond* out_cond) const {
+    if (flags_zero_armed_reg_ == gpr_reg && flags_zero_armed_is64_ == is64 &&
+        gpr_reg >= 0) {
+      *out_cond = flags_zero_armed_cond_;
+      return true;
+    }
+    return false;
+  }
+  bool FlagsHoldZeroTest(int gpr_reg, bool is64) const {
+    return flags_zero_armed_reg_ == gpr_reg && flags_zero_armed_is64_ == is64 &&
+           gpr_reg >= 0 && flags_zero_armed_cond_ == Xbyak_aarch64::NE;
+  }
+  // Reset and Shift govern every adjacent-sequence handoff, not just the
+  // flags: the w16 forwarding below rides on the same fresh/armed pair.
+  void ResetFlagsZeroTest() {
+    flags_zero_fresh_reg_ = flags_zero_armed_reg_ = -1;
+    w16_holds_fresh_ = w16_holds_armed_ = nullptr;
+  }
+  void ShiftFlagsZeroTest() {
+    flags_zero_armed_reg_ = flags_zero_fresh_reg_;
+    flags_zero_armed_is64_ = flags_zero_fresh_is64_;
+    flags_zero_armed_cond_ = flags_zero_fresh_cond_;
+    flags_zero_fresh_reg_ = -1;
+    w16_holds_armed_ = w16_holds_fresh_;
+    w16_holds_fresh_ = nullptr;
+  }
+
+  // One-shot forwarding of an indirect-call target into w16: LOAD_CONTEXT
+  // declares that it loaded this HIR value directly into w16, and only the
+  // immediately following instruction may consume it (same shift/reset rules
+  // as the flags fusion; nothing between the two can touch w16).
+  void DeclareW16Holds(const hir::Value* value) { w16_holds_fresh_ = value; }
+  bool W16Holds(const hir::Value* value) const {
+    return value && w16_holds_armed_ == value;
+  }
 
   void MarkSourceOffset(const hir::Instr* i);
 
@@ -128,6 +181,8 @@ class A64Emitter : public Xbyak_aarch64::CodeGenerator {
 
   void Call(const hir::Instr* instr, GuestFunction* function);
   void CallIndirect(const hir::Instr* instr, int reg_index);
+  // Shared by Call and CallIndirect: w16 (guest address) -> x9 (host target).
+  void EmitEncodedIndirectionLookup();
   void CallExtern(const hir::Instr* instr, const Function* function);
   // Emits a PPC __savegprlr_N/__restgprlr_N helper body inline instead of
   // calling it. Returns false when the callee is not a GPR saverest helper.
@@ -151,13 +206,47 @@ class A64Emitter : public Xbyak_aarch64::CodeGenerator {
   void PopStackpoint();
   void EnsureSynchronizedGuestAndHostStack();
 
-  static void HandleStackpointOverflowError(ppc::PPCContext* context);
-
+  // After a conditional region (TRAP_TRUE / CALL_*_TRUE), the taken path's
+  // tracker state must meet the skip path's entry state: keep it only when
+  // both agree.
+  void MergeFpcrModeAfterConditional(FPCRMode skip_path_mode) {
+    if (fpcr_mode_ != skip_path_mode) {
+      fpcr_mode_ = FPCRMode::Unknown;
+    }
+  }
+  FPCRMode fpcr_mode() const { return fpcr_mode_; }
+  // Switches to Fpu if a VMX mode is tracked and drops to Unknown. Only
+  // SET_NJM needs this: it rewrites the VMX FPCR images, so a tracked VMX
+  // mode no longer describes the register.
   void ForgetFpcrMode() {
     if (IsVmxFpcrMode(fpcr_mode_)) {
       ChangeFpcrMode(FPCRMode::Fpu);
     }
     fpcr_mode_ = FPCRMode::Unknown;
+  }
+  // Re-emits the switch to |mode| even though the tracker already claims it:
+  // for a cold path whose host call clobbered FPCR at runtime while the hot
+  // path's static mode stays |mode|.
+  void ReloadFpcrMode(FPCRMode mode) {
+    fpcr_mode_ = FPCRMode::Unknown;
+    ChangeFpcrMode(mode);
+    fpcr_mode_ = mode;
+  }
+  // Host and cross-function transitions must run in FPU mode. The switch is
+  // emitted when a VMX mode is tracked, and also when the tracker holds
+  // Unknown in a function that touches VEC128 at all, since Unknown may be
+  // VMX at runtime; a function with no VEC128 can never be in a VMX mode and
+  // skips the guard entirely.
+  void EnsureFpuFpcrModeForTransition() {
+    if (IsVmxFpcrMode(fpcr_mode_) ||
+        (fpcr_mode_ == FPCRMode::Unknown && function_has_vmx_)) {
+      ChangeFpcrMode(FPCRMode::Fpu);
+    }
+    // The transition this guards returns with FPCR back in the scalar FPU
+    // state: a guest callee restores it before returning, and host calls
+    // come back through the guest-to-host or resolve thunk, both of which
+    // reload fpcr_fpu. The post-call code may rely on that.
+    fpcr_mode_ = FPCRMode::Fpu;
   }
   bool ChangeFpcrMode(FPCRMode new_mode, bool already_set = false);
   bool IsFeatureEnabled(uint64_t feature_flag) const {
@@ -231,6 +320,11 @@ class A64Emitter : public Xbyak_aarch64::CodeGenerator {
                  const Xbyak_aarch64::Label& label) {
     CodeGenerator::cbnz(rt, label);
   }
+  // +/-32 KiB only; guard with near_tbz_branches_safe_.
+  void tbnz_near(const Xbyak_aarch64::WReg& rt, uint32_t bit,
+                 const Xbyak_aarch64::Label& label) {
+    CodeGenerator::tbnz(rt, bit, label);
+  }
 
   // Shadow of CodeGenerator::L that records the bind offset so later
   // branches to this label can be emitted in single-instruction form.
@@ -284,6 +378,24 @@ class A64Emitter : public Xbyak_aarch64::CodeGenerator {
   Arena source_map_arena_;
 
   size_t stack_size_ = 0;
+  // True when every tail label of the current function provably sits within
+  // the +/-1 MiB reach of cbnz/b.cond (set per function in Emit).
+  bool near_tail_branches_safe_ = false;
+  // Same, for tbnz's +/-32 KiB reach.
+  bool near_tbz_branches_safe_ = false;
+  // NZCV fusion: the previous HIR instruction's sequence declared that the
+  // flags currently hold a zero-test of this GPR (ANDS). -1 = nothing.
+  // `fresh` is what the current sequence declares; the emit loop shifts it
+  // into `armed` between instructions, so `armed` can never leak past one
+  // instruction, a label bind, or a block boundary.
+  int flags_zero_fresh_reg_ = -1;
+  Xbyak_aarch64::Cond flags_zero_fresh_cond_ = Xbyak_aarch64::NE;
+  Xbyak_aarch64::Cond flags_zero_armed_cond_ = Xbyak_aarch64::NE;
+  bool flags_zero_fresh_is64_ = false;
+  int flags_zero_armed_reg_ = -1;
+  bool flags_zero_armed_is64_ = false;
+  const hir::Value* w16_holds_fresh_ = nullptr;
+  const hir::Value* w16_holds_armed_ = nullptr;
 
   static const uint32_t gpr_reg_map_[GPR_COUNT];
   static const uint32_t vec_reg_map_[VEC_COUNT];
@@ -329,6 +441,42 @@ class A64Emitter : public Xbyak_aarch64::CodeGenerator {
   static constexpr int64_t kTestBranchBackwardRange = (1ll << 15) - 8;
 
   FPCRMode fpcr_mode_ = FPCRMode::Unknown;
+  // Whether the current function contains any VEC128-typed instruction (set
+  // per function in Emit); gates the Unknown-mode transition guard.
+  bool function_has_vmx_ = false;
+  // FPCR tracking contract. Lattice {Unknown, Fpu, Vmx, VmxDaz} with
+  // meet(a, b) = a if a == b else Unknown. Every guest function is entered
+  // in Fpu: the host-to-guest thunk restores fpcr_fpu on entry, every call
+  // site runs EnsureFpuFpcrModeForTransition, every callee returns in Fpu,
+  // the guest-to-host thunks restore fpcr_fpu after host callbacks and the
+  // resolve thunk restores it after the host resolve. Within a function,
+  // every branch records the tracker's mode at the branch point on its
+  // target's incoming edges, block ends record the fall-through mode unless
+  // the last instruction is an unconditional BRANCH, and the function entry
+  // records Fpu on the first block; a block is seeded with the meet only
+  // when its recorded count equals the expected count from the pre-scan,
+  // otherwise it starts Unknown. RETURN/RETURN_TRUE do not participate and
+  // the epilog has no guard: PPC blr lowers to CALL_INDIRECT, which carries
+  // the guard, so they are unreachable from the frontend today.
+  // FPCR seeding state, per function: how many predecessor edges each block
+  // expects (from the final-HIR pre-scan), the meet of the modes recorded so
+  // far on its incoming edges, and the authoritative label->block mapping.
+  struct IncomingFpcr {
+    FPCRMode meet = FPCRMode::Unknown;
+    uint32_t count = 0;
+  };
+  std::unordered_map<const hir::Block*, uint32_t> expected_preds_;
+  std::unordered_map<const hir::Block*, IncomingFpcr> incoming_fpcr_;
+  std::unordered_map<const hir::Label*, const hir::Block*> label_block_;
+  void RecordIncomingFpcr(const hir::Block* target, FPCRMode mode) {
+    auto& in = incoming_fpcr_[target];
+    if (in.count == 0) {
+      in.meet = mode;
+    } else if (in.meet != mode) {
+      in.meet = FPCRMode::Unknown;
+    }
+    ++in.count;
+  }
   bool synchronize_stack_on_next_instruction_ = false;
 };
 

--- a/src/xenia/cpu/backend/a64/a64_seq_control.cc
+++ b/src/xenia/cpu/backend/a64/a64_seq_control.cc
@@ -255,37 +255,53 @@ EMITTER_OPCODE_TABLE(OPCODE_TRAP, TRAP);
 struct TRAP_TRUE_I8
     : Sequence<TRAP_TRUE_I8, I<OPCODE_TRAP_TRUE, VoidOp, I8Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    const FPCRMode entry_mode = e.fpcr_mode();
     auto& skip = e.NewCachedLabel();
     e.cbz_near(i.src1, skip);
     e.Trap(i.instr->flags);
     e.L(skip);
+    // The trap path's host transition leaves the tracker Known-Fpu; the
+    // skip path kept entry state. Meet them.
+    e.MergeFpcrModeAfterConditional(entry_mode);
   }
 };
 struct TRAP_TRUE_I16
     : Sequence<TRAP_TRUE_I16, I<OPCODE_TRAP_TRUE, VoidOp, I16Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    const FPCRMode entry_mode = e.fpcr_mode();
     auto& skip = e.NewCachedLabel();
     e.cbz_near(i.src1, skip);
     e.Trap(i.instr->flags);
     e.L(skip);
+    // The trap path's host transition leaves the tracker Known-Fpu; the
+    // skip path kept entry state. Meet them.
+    e.MergeFpcrModeAfterConditional(entry_mode);
   }
 };
 struct TRAP_TRUE_I32
     : Sequence<TRAP_TRUE_I32, I<OPCODE_TRAP_TRUE, VoidOp, I32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    const FPCRMode entry_mode = e.fpcr_mode();
     auto& skip = e.NewCachedLabel();
     e.cbz_near(i.src1, skip);
     e.Trap(i.instr->flags);
     e.L(skip);
+    // The trap path's host transition leaves the tracker Known-Fpu; the
+    // skip path kept entry state. Meet them.
+    e.MergeFpcrModeAfterConditional(entry_mode);
   }
 };
 struct TRAP_TRUE_I64
     : Sequence<TRAP_TRUE_I64, I<OPCODE_TRAP_TRUE, VoidOp, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    const FPCRMode entry_mode = e.fpcr_mode();
     auto& skip = e.NewCachedLabel();
     e.cbz_near(i.src1, skip);
     e.Trap(i.instr->flags);
     e.L(skip);
+    // The trap path's host transition leaves the tracker Known-Fpu; the
+    // skip path kept entry state. Meet them.
+    e.MergeFpcrModeAfterConditional(entry_mode);
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_TRAP_TRUE, TRAP_TRUE_I8, TRAP_TRUE_I16,
@@ -339,44 +355,52 @@ struct CALL_TRUE_I8
     : Sequence<CALL_TRUE_I8, I<OPCODE_CALL_TRUE, VoidOp, I8Op, SymbolOp>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
     assert_true(i.src2.value->is_guest());
+    const FPCRMode entry_mode = e.fpcr_mode();
     auto& skip = e.NewCachedLabel();
     e.cbz_near(i.src1, skip);
     e.Call(i.instr, static_cast<GuestFunction*>(i.src2.value));
     e.L(skip);
-    e.ForgetFpcrMode();
+    // Post-call state is Known-Fpu; the skip path kept entry state.
+    e.MergeFpcrModeAfterConditional(entry_mode);
   }
 };
 struct CALL_TRUE_I16
     : Sequence<CALL_TRUE_I16, I<OPCODE_CALL_TRUE, VoidOp, I16Op, SymbolOp>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
     assert_true(i.src2.value->is_guest());
+    const FPCRMode entry_mode = e.fpcr_mode();
     auto& skip = e.NewCachedLabel();
     e.cbz_near(i.src1, skip);
     e.Call(i.instr, static_cast<GuestFunction*>(i.src2.value));
     e.L(skip);
-    e.ForgetFpcrMode();
+    // Post-call state is Known-Fpu; the skip path kept entry state.
+    e.MergeFpcrModeAfterConditional(entry_mode);
   }
 };
 struct CALL_TRUE_I32
     : Sequence<CALL_TRUE_I32, I<OPCODE_CALL_TRUE, VoidOp, I32Op, SymbolOp>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
     assert_true(i.src2.value->is_guest());
+    const FPCRMode entry_mode = e.fpcr_mode();
     auto& skip = e.NewCachedLabel();
     e.cbz_near(i.src1, skip);
     e.Call(i.instr, static_cast<GuestFunction*>(i.src2.value));
     e.L(skip);
-    e.ForgetFpcrMode();
+    // Post-call state is Known-Fpu; the skip path kept entry state.
+    e.MergeFpcrModeAfterConditional(entry_mode);
   }
 };
 struct CALL_TRUE_I64
     : Sequence<CALL_TRUE_I64, I<OPCODE_CALL_TRUE, VoidOp, I64Op, SymbolOp>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
     assert_true(i.src2.value->is_guest());
+    const FPCRMode entry_mode = e.fpcr_mode();
     auto& skip = e.NewCachedLabel();
     e.cbz_near(i.src1, skip);
     e.Call(i.instr, static_cast<GuestFunction*>(i.src2.value));
     e.L(skip);
-    e.ForgetFpcrMode();
+    // Post-call state is Known-Fpu; the skip path kept entry state.
+    e.MergeFpcrModeAfterConditional(entry_mode);
   }
 };
 struct CALL_TRUE_F32
@@ -408,10 +432,12 @@ struct CALL_INDIRECT
         e.mov(e.w16, static_cast<uint32_t>(i.src1.constant()));
         e.CallIndirect(i.instr, 16);
       }
+    } else if (e.W16Holds(i.src1.value)) {
+      // The preceding LOAD_CONTEXT loaded the target straight into w16.
+      e.CallIndirect(i.instr, 16);
     } else {
       e.CallIndirect(i.instr, i.src1.reg().getIdx());
     }
-    e.ForgetFpcrMode();
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_CALL_INDIRECT, CALL_INDIRECT);
@@ -423,60 +449,80 @@ struct CALL_INDIRECT_TRUE_I8
     : Sequence<CALL_INDIRECT_TRUE_I8,
                I<OPCODE_CALL_INDIRECT_TRUE, VoidOp, I8Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    const FPCRMode entry_mode = e.fpcr_mode();
     auto& skip = e.NewCachedLabel();
     e.cbz_near(i.src1, skip);
     if (i.src2.is_constant) {
       e.mov(e.w16, static_cast<uint32_t>(i.src2.constant()));
       e.CallIndirect(i.instr, 16);
+    } else if (e.W16Holds(i.src2.value)) {
+      e.CallIndirect(i.instr, 16);
     } else {
       e.CallIndirect(i.instr, i.src2.reg().getIdx());
     }
     e.L(skip);
+    // Post-call state is Known-Fpu; the skip path kept entry state.
+    e.MergeFpcrModeAfterConditional(entry_mode);
   }
 };
 struct CALL_INDIRECT_TRUE_I16
     : Sequence<CALL_INDIRECT_TRUE_I16,
                I<OPCODE_CALL_INDIRECT_TRUE, VoidOp, I16Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    const FPCRMode entry_mode = e.fpcr_mode();
     auto& skip = e.NewCachedLabel();
     e.cbz_near(i.src1, skip);
     if (i.src2.is_constant) {
       e.mov(e.w16, static_cast<uint32_t>(i.src2.constant()));
       e.CallIndirect(i.instr, 16);
+    } else if (e.W16Holds(i.src2.value)) {
+      e.CallIndirect(i.instr, 16);
     } else {
       e.CallIndirect(i.instr, i.src2.reg().getIdx());
     }
     e.L(skip);
+    // Post-call state is Known-Fpu; the skip path kept entry state.
+    e.MergeFpcrModeAfterConditional(entry_mode);
   }
 };
 struct CALL_INDIRECT_TRUE_I32
     : Sequence<CALL_INDIRECT_TRUE_I32,
                I<OPCODE_CALL_INDIRECT_TRUE, VoidOp, I32Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    const FPCRMode entry_mode = e.fpcr_mode();
     auto& skip = e.NewCachedLabel();
     e.cbz_near(i.src1, skip);
     if (i.src2.is_constant) {
       e.mov(e.w16, static_cast<uint32_t>(i.src2.constant()));
       e.CallIndirect(i.instr, 16);
+    } else if (e.W16Holds(i.src2.value)) {
+      e.CallIndirect(i.instr, 16);
     } else {
       e.CallIndirect(i.instr, i.src2.reg().getIdx());
     }
     e.L(skip);
+    // Post-call state is Known-Fpu; the skip path kept entry state.
+    e.MergeFpcrModeAfterConditional(entry_mode);
   }
 };
 struct CALL_INDIRECT_TRUE_I64
     : Sequence<CALL_INDIRECT_TRUE_I64,
                I<OPCODE_CALL_INDIRECT_TRUE, VoidOp, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    const FPCRMode entry_mode = e.fpcr_mode();
     auto& skip = e.NewCachedLabel();
     e.cbz_near(i.src1, skip);
     if (i.src2.is_constant) {
       e.mov(e.w16, static_cast<uint32_t>(i.src2.constant()));
       e.CallIndirect(i.instr, 16);
+    } else if (e.W16Holds(i.src2.value)) {
+      e.CallIndirect(i.instr, 16);
     } else {
       e.CallIndirect(i.instr, i.src2.reg().getIdx());
     }
     e.L(skip);
+    // Post-call state is Known-Fpu; the skip path kept entry state.
+    e.MergeFpcrModeAfterConditional(entry_mode);
   }
 };
 struct CALL_INDIRECT_TRUE_F32

--- a/src/xenia/cpu/backend/a64/a64_seq_util.h
+++ b/src/xenia/cpu/backend/a64/a64_seq_util.h
@@ -50,8 +50,10 @@ inline void EmitWithFpcrMode(A64Emitter& e, FPCRMode mode, Fn&& emit_op) {
   // Enter the requested FPCR mode using tracked lazy switching.  If the
   // emitter is already in that mode (e.g. consecutive VMX ops in the same
   // basic block) this is a no-op — no system register access at all.
-  // FPU mode is restored at block boundaries and calls via ForgetFpcrMode,
-  // or on demand by scalar FP sequences via ChangeFpcrMode(Fpu).
+  // FPU mode is re-established at host and cross-function transitions via
+  // EnsureFpuFpcrModeForTransition, or on demand by scalar FP sequences via
+  // ChangeFpcrMode(Fpu); block entries seed the tracker from the
+  // predecessors' recorded modes (see a64_emitter.h).
   e.ChangeFpcrMode(mode);
   emit_op();
 }
@@ -298,6 +300,13 @@ inline int SrcVReg(A64Emitter& e, const T& op, int scratch_idx) {
   return op.reg().getIdx();
 }
 
+// Copies a source into scratch register `slot` unless it already sits there.
+inline void MoveToScratchVReg(A64Emitter& e, int src, int slot) {
+  if (src != slot) {
+    e.mov(VReg(slot).b16, VReg(src).b16);
+  }
+}
+
 // Compute a guest memory address, returning the XReg for [x21, xN] addressing.
 // For constants, loads the address into x0 (scratch).
 inline XReg ComputeMemoryAddress(A64Emitter& e, const I64Op& guest) {
@@ -359,26 +368,48 @@ inline XReg AddGuestMemoryOffset(A64Emitter& e, const XReg& base,
 
 // Flush denormal float32 lanes to zero in a NEON register (in-place).
 // A float32 is denormal when 0 < abs(val) < 0x00800000.
-// vreg must not equal sa or sb.
 // This is needed because FPCR.FZ may not flush denormal inputs on all ARM64
 // implementations (the ARM spec says input flushing is implementation-defined).
+//
+// Loads the threshold the comparison below needs: 0x01000000, the smallest
+// normal magnitude with the sign shifted out.
+inline void LoadDenormalThreshold_V128(A64Emitter& e, int k) {
+  e.movi(VReg(k).s4, 0x1, LSL, 24);
+}
+
+// The K-preloaded body. val<<1 drops the sign and doubles the magnitude:
+// denormals land in [0x00000002, 0x00FFFFFE] and zeros at 0, both below
+// 0x01000000; the smallest normal lands exactly on it. Masking zero lanes too
+// is deliberate - bic of bits 30:0 is a no-op on a zero of either sign - so no
+// instruction is spent excluding them. ushr clears bit 31 of the mask, which
+// keeps the sign: -denormal flushes to -0, +denormal to +0.
+// vreg must equal neither k nor t.
+inline void FlushDenormalsWithK_V128(A64Emitter& e, int vreg, int k, int t) {
+  e.shl(VReg(t).s4, VReg(vreg).s4, 1);
+  e.cmhi(VReg(t).s4, VReg(k).s4,
+         VReg(t).s4);                 // mask: all-1s for denormal-or-zero lanes
+  e.ushr(VReg(t).s4, VReg(t).s4, 1);  // clear bit 31: preserve the sign
+  e.bic(VReg(vreg).b16, VReg(vreg).b16, VReg(t).b16);
+}
+
+// One-shot form for single flushes; multi-flush sites load K once themselves.
+// Runtime NJ gate: with VSCR.NJ clear, denormals pass through untouched, so
+// the software flushes must not run. One flags load + tbz brackets a flush
+// block; FZ-input hosts never emit these blocks at all. w17 is free in every
+// vector FP sequence (the emitter reserves it as scratch).
+inline void EmitSkipFlushUnlessNJM(A64Emitter& e, Xbyak_aarch64::Label& skip) {
+  e.ldr(e.w17, Xbyak_aarch64::ptr(e.x19, static_cast<uint32_t>(offsetof(
+                                             A64BackendContext, flags))));
+  e.tbz(e.w17, kA64BackendNJMOn, skip);
+}
+
 inline void FlushDenormals_V128(A64Emitter& e, int vreg, int sa = 2,
                                 int sb = 3) {
-  // val<<1 removes the sign bit and doubles the value.
-  // Denormals become [0x00000002, 0x00FFFFFE]; zeros become 0x00000000.
-  // (val<<1) - 1: wraps 0→0xFFFFFFFF (excluded),
-  // denorms→[0x00000001,0x00FFFFFD]. Denormal iff ((val<<1) - 1) < 0x00FFFFFF
-  // (unsigned).
-  e.shl(VReg(sa).s4, VReg(vreg).s4, 1);
-  e.movi(VReg(sb).s4, 1u);
-  e.sub(VReg(sa).s4, VReg(sa).s4, VReg(sb).s4);
-  e.mvni(VReg(sb).s4, 0xFFu, LSL, 24);  // 0x00FFFFFF
-  e.cmhi(VReg(sb).s4, VReg(sb).s4,
-         VReg(sa).s4);  // mask: all-1s for denormal lanes
-  // Clear only bits 30:0 (preserve sign bit 31) so -denormal → -0, +denormal →
-  // +0.
-  e.ushr(VReg(sa).s4, VReg(sb).s4, 1);  // sa = mask with bit 31 cleared
-  e.bic(VReg(vreg).b16, VReg(vreg).b16, VReg(sa).b16);
+  Xbyak_aarch64::Label no_flush;
+  EmitSkipFlushUnlessNJM(e, no_flush);
+  LoadDenormalThreshold_V128(e, sa);
+  FlushDenormalsWithK_V128(e, vreg, sa, sb);
+  e.L(no_flush);
 }
 
 // Fixup for vmaxfp/vminfp NaN lanes.
@@ -409,16 +440,17 @@ inline void PrepareVmxFpSources(A64Emitter& e, const T1& op1, const T2& op2,
   int s1 = SrcVReg(e, op1, 0);
   int s2 = SrcVReg(e, op2, 1);
   // Copy to scratch v0/v1 so we don't modify live allocated registers.
-  if (s1 != 0) {
-    e.mov(VReg(0).b16, VReg(s1).b16);
-  }
-  if (s2 != 1) {
-    e.mov(VReg(1).b16, VReg(s2).b16);
-  }
-  // Flush denormal inputs in software only if FPCR.FZ doesn't handle it.
+  MoveToScratchVReg(e, s1, 0);
+  MoveToScratchVReg(e, s2, 1);
+  // Flush denormal inputs in software only if FPCR.FZ doesn't handle it,
+  // and only while the guest actually has NJ on.
   if (!e.IsFeatureEnabled(xe::arm64::kA64FZFlushesInputs)) {
-    FlushDenormals_V128(e, 0);
-    FlushDenormals_V128(e, 1);
+    Xbyak_aarch64::Label no_flush;
+    EmitSkipFlushUnlessNJM(e, no_flush);
+    LoadDenormalThreshold_V128(e, 2);
+    FlushDenormalsWithK_V128(e, 0, 2, 3);
+    FlushDenormalsWithK_V128(e, 1, 2, 3);
+    e.L(no_flush);
   }
   out_s1 = 0;
   out_s2 = 1;
@@ -448,57 +480,107 @@ inline void FixupVmxNan_V128(A64Emitter& e) {
   e.orr(VReg(2).b16, VReg(2).b16, VReg(1).b16);
 }
 
-// Load an FMA's three sources into the registers FixupVmxNan_V128_Fma reads:
-// v0 = src1 (A), v1 = src2 (C), v3 = src3 (B), flushing input denormals in
-// software where FPCR.FZ does not. Uses v2 and `tmp` as flush scratch.
+// Load an FMA's three sources for the FMA and its NaN fixup, flushing input
+// denormals in software where FPCR.FZ does not. Writes the register indices
+// holding A, C, B to out_a/out_c/out_b.
+//
+// Where software flushing runs, the sources are copied into scratch v0/v1/v3
+// so the flush can modify them in place (allocated registers may be live-out).
+// On kA64FZFlushesInputs hosts nothing modifies them, so allocated sources
+// feed the FMA and fixup directly and the three copies disappear; constants
+// still materialise into the scratch bank via SrcVReg.
 template <typename T1, typename T2, typename T3>
 inline void PrepareVmxFmaSources(A64Emitter& e, const T1& op1, const T2& op2,
-                                 const T3& op3, int tmp) {
+                                 const T3& op3, int tmp, int* out_a, int* out_c,
+                                 int* out_b) {
   const int s1 = SrcVReg(e, op1, 0);
-  if (s1 != 0) {
-    e.mov(VReg(0).b16, VReg(s1).b16);
-  }
   const int s2 = SrcVReg(e, op2, 1);
-  if (s2 != 1) {
-    e.mov(VReg(1).b16, VReg(s2).b16);
-  }
   const int s3 = SrcVReg(e, op3, 3);
-  if (s3 != 3) {
-    e.mov(VReg(3).b16, VReg(s3).b16);
+  if (e.IsFeatureEnabled(xe::arm64::kA64FZFlushesInputs)) {
+    *out_a = s1;
+    *out_c = s2;
+    *out_b = s3;
+    return;
   }
-  if (!e.IsFeatureEnabled(xe::arm64::kA64FZFlushesInputs)) {
-    FlushDenormals_V128(e, 0, 2, tmp);
-    FlushDenormals_V128(e, 1, 2, tmp);
-    FlushDenormals_V128(e, 3, 2, tmp);
+  MoveToScratchVReg(e, s1, 0);
+  MoveToScratchVReg(e, s2, 1);
+  MoveToScratchVReg(e, s3, 3);
+  // The FMA family follows NJ like every other VMX op unless the
+  // accurate-flush mode pins it always-on (see VmxDenormalFlushFpcrMode).
+  Xbyak_aarch64::Label no_flush;
+  const bool gate_on_njm = !cvars::accurate_vmx_denormal_flush;
+  if (gate_on_njm) {
+    EmitSkipFlushUnlessNJM(e, no_flush);
   }
+  LoadDenormalThreshold_V128(e, 2);
+  FlushDenormalsWithK_V128(e, 0, 2, tmp);
+  FlushDenormalsWithK_V128(e, 1, 2, tmp);
+  FlushDenormalsWithK_V128(e, 3, 2, tmp);
+  if (gate_on_njm) {
+    e.L(no_flush);
+  }
+  *out_a = 0;
+  *out_c = 1;
+  *out_b = 3;
 }
 
 // Fix PPC NaN propagation for a V128 FMA result (3 source operands).
 // Hardware returns the first NaN in A, B, C order, quieted, and the HIR
 // operands are (A, C, B). An invalid operation with no NaN operand needs
 // nothing: ARM's default NaN is already the one PPC produces.
-// Expects: v0 = flushed A, v1 = flushed C, v3 = flushed B, v2 = the FMA result.
-// `tmp` must be a register free until the result is stored, which v0-v3 cannot
-// supply. Modifies v2 in place. Clobbers v1 and tmp.
-inline void FixupVmxNan_V128_Fma(A64Emitter& e, int tmp) {
+// a/c/b hold the (flushed) sources; v2 holds the FMA result, modified in
+// place. `tmp` is live scratch across the whole fixup: it must differ from
+// a, c, b and v2 and must not alias a live allocated register. `qs` is
+// clobbered only after the sources are dead, so any scratch-bank register
+// other than tmp and v2 serves, even one that held a source.
+inline void FixupVmxNan_V128_Fma(A64Emitter& e, int a, int c, int b, int tmp,
+                                 int qs) {
   using namespace Xbyak_aarch64;
-  // Lowest priority first, so an earlier operand overwrites a later one: C,
-  // then B, then A. BIF inserts an operand wherever its self-compare is false,
-  // which is exactly where that operand is NaN.
-  e.fcmeq(VReg(tmp).s4, VReg(1).s4, VReg(1).s4);
-  e.bif(VReg(2).b16, VReg(1).b16, VReg(tmp).b16);
-  e.fcmeq(VReg(tmp).s4, VReg(3).s4, VReg(3).s4);
-  e.bif(VReg(2).b16, VReg(3).b16, VReg(tmp).b16);
-  e.fcmeq(VReg(tmp).s4, VReg(0).s4, VReg(0).s4);
-  e.bif(VReg(2).b16, VReg(0).b16, VReg(tmp).b16);
+  // Result-gated: FMLA propagates any operand NaN into that result lane, and
+  // an invalid operation produces the default NaN, so a result with no NaN
+  // lane needs no fixing. Four inline instructions decide it; the
+  // ten-instruction fixup sits in the function tail when the near-branch
+  // bound allows, inline behind a branch-over otherwise. (The x64 backend's
+  // vptest gate relies on the same invariant.)
+  auto& done = e.NewCachedLabel();
+  auto emit_fixup = [a, c, b, tmp, qs, &done](A64Emitter& e) {
+    // Lowest priority first, so an earlier operand overwrites a later one: C,
+    // then B, then A. BIF inserts an operand wherever its self-compare is
+    // false, which is exactly where that operand is NaN.
+    e.fcmeq(VReg(tmp).s4, VReg(c).s4, VReg(c).s4);
+    e.bif(VReg(2).b16, VReg(c).b16, VReg(tmp).b16);
+    e.fcmeq(VReg(tmp).s4, VReg(b).s4, VReg(b).s4);
+    e.bif(VReg(2).b16, VReg(b).b16, VReg(tmp).b16);
+    e.fcmeq(VReg(tmp).s4, VReg(a).s4, VReg(a).s4);
+    e.bif(VReg(2).b16, VReg(a).b16, VReg(tmp).b16);
 
-  // Quiet whatever NaN each lane ended up with. A lane still holding the
-  // arithmetic result is either not NaN or already the default NaN, so this
-  // only ever quiets an operand that was signalling.
-  e.fcmeq(VReg(tmp).s4, VReg(2).s4, VReg(2).s4);
-  e.movi(VReg(1).s4, 0x40, LSL, 16);
-  e.bic(VReg(1).b16, VReg(1).b16, VReg(tmp).b16);
-  e.orr(VReg(2).b16, VReg(2).b16, VReg(1).b16);
+    // Quiet whatever NaN each lane ended up with. A lane still holding the
+    // arithmetic result is either not NaN or already the default NaN, so this
+    // only ever quiets an operand that was signalling.
+    e.fcmeq(VReg(tmp).s4, VReg(2).s4, VReg(2).s4);
+    e.movi(VReg(qs).s4, 0x40, LSL, 16);
+    e.bic(VReg(qs).b16, VReg(qs).b16, VReg(tmp).b16);
+    e.orr(VReg(2).b16, VReg(2).b16, VReg(qs).b16);
+    e.b(done);
+  };
+
+  e.fcmeq(VReg(tmp).s4, VReg(2).s4, VReg(2).s4);  // all-ones where not NaN
+  e.uminv(SReg(tmp), VReg(tmp).s4);               // 0 iff any lane is NaN
+  e.fmov(WReg(0), SReg(tmp));
+  if (e.near_tail_branches_safe()) {
+    auto& slow = e.AddToTail(
+        [emit_fixup](A64Emitter& e, Xbyak_aarch64::Label&) { emit_fixup(e); });
+    e.cbz_near(WReg(0), slow);
+  } else {
+    // Function too large to prove the +/-1 MiB reach of a near branch to the
+    // tail: keep the fixup inline, jumped over on the fast path.
+    auto& slow = e.NewCachedLabel();
+    e.cbz(WReg(0), slow);
+    e.b(done);
+    e.L(slow);
+    emit_fixup(e);
+  }
+  e.L(done);
 }
 
 // VMX float32x4 binary operations with full PPC semantics.

--- a/src/xenia/cpu/backend/a64/a64_seq_vector.cc
+++ b/src/xenia/cpu/backend/a64/a64_seq_vector.cc
@@ -674,9 +674,152 @@ EMITTER_OPCODE_TABLE(OPCODE_VECTOR_NONE_SET, VECTOR_NONE_SET);
 // ============================================================================
 // OPCODE_VECTOR_SHL
 // ============================================================================
+// Shift-by-constant fast paths for the VMX variable shifts. The frontend
+// only produces splatted shift amounts, but any constant folds: uniform
+// amounts use the immediate-form shift (one instruction), non-uniform ones
+// pre-mask (and pre-negate for right shifts) the constant on the host and
+// keep a single register-form shift. Returns true when it emitted.
+//
+// kind: 0 = shl (ushl), 1 = shr (ushr/-ushl), 2 = sha (sshr/-sshl).
+static bool TryEmitConstantVectorShift(A64Emitter& e, const V128Op& dest,
+                                       const V128Op& src1, const V128Op& src2,
+                                       uint32_t part_type, int kind) {
+  if (!src2.is_constant) {
+    return false;
+  }
+  const vec128_t amounts = src2.constant();
+  const int d = dest.reg().getIdx();
+  const int s1 = SrcVReg(e, src1, 0);
+
+  uint32_t lane_bits, mask, lanes;
+  switch (part_type) {
+    case INT8_TYPE:
+      lane_bits = 8;
+      mask = 0x07;
+      lanes = 16;
+      break;
+    case INT16_TYPE:
+      lane_bits = 16;
+      mask = 0x0F;
+      lanes = 8;
+      break;
+    case INT32_TYPE:
+      lane_bits = 32;
+      mask = 0x1F;
+      lanes = 4;
+      break;
+    default:
+      return false;
+  }
+  auto lane_at = [&](uint32_t k) -> uint32_t {
+    if (lane_bits == 8) {
+      return amounts.u8[k];
+    }
+    if (lane_bits == 16) {
+      return amounts.u16[k];
+    }
+    return amounts.u32[k];
+  };
+
+  bool uniform = true;
+  const uint32_t amt0 = lane_at(0) & mask;
+  for (uint32_t k = 1; k < lanes; ++k) {
+    if ((lane_at(k) & mask) != amt0) {
+      uniform = false;
+      break;
+    }
+  }
+
+  if (uniform) {
+    if (amt0 == 0) {
+      // ushr/sshr cannot encode #0; the shift is the identity.
+      if (d != s1) {
+        e.mov(VReg(d).b16, VReg(s1).b16);
+      }
+      return true;
+    }
+    switch (part_type) {
+      case INT8_TYPE:
+        if (kind == 0) {
+          e.shl(VReg(d).b16, VReg(s1).b16, amt0);
+        } else if (kind == 1) {
+          e.ushr(VReg(d).b16, VReg(s1).b16, amt0);
+        } else {
+          e.sshr(VReg(d).b16, VReg(s1).b16, amt0);
+        }
+        break;
+      case INT16_TYPE:
+        if (kind == 0) {
+          e.shl(VReg(d).h8, VReg(s1).h8, amt0);
+        } else if (kind == 1) {
+          e.ushr(VReg(d).h8, VReg(s1).h8, amt0);
+        } else {
+          e.sshr(VReg(d).h8, VReg(s1).h8, amt0);
+        }
+        break;
+      default:
+        if (kind == 0) {
+          e.shl(VReg(d).s4, VReg(s1).s4, amt0);
+        } else if (kind == 1) {
+          e.ushr(VReg(d).s4, VReg(s1).s4, amt0);
+        } else {
+          e.sshr(VReg(d).s4, VReg(s1).s4, amt0);
+        }
+        break;
+    }
+    return true;
+  }
+
+  // Non-uniform: fold the mask (and the negation for right shifts) on the
+  // host and load the finished per-lane shift vector.
+  vec128_t folded = {};
+  for (uint32_t k = 0; k < lanes; ++k) {
+    int32_t v = static_cast<int32_t>(lane_at(k) & mask);
+    if (kind != 0) {
+      v = -v;
+    }
+    if (lane_bits == 8) {
+      folded.i8[k] = static_cast<int8_t>(v);
+    } else if (lane_bits == 16) {
+      folded.i16[k] = static_cast<int16_t>(v);
+    } else {
+      folded.i32[k] = v;
+    }
+  }
+  LoadV128Const(e, 2, folded);
+  switch (part_type) {
+    case INT8_TYPE:
+      if (kind == 2) {
+        e.sshl(VReg(d).b16, VReg(s1).b16, VReg(2).b16);
+      } else {
+        e.ushl(VReg(d).b16, VReg(s1).b16, VReg(2).b16);
+      }
+      break;
+    case INT16_TYPE:
+      if (kind == 2) {
+        e.sshl(VReg(d).h8, VReg(s1).h8, VReg(2).h8);
+      } else {
+        e.ushl(VReg(d).h8, VReg(s1).h8, VReg(2).h8);
+      }
+      break;
+    default:
+      if (kind == 2) {
+        e.sshl(VReg(d).s4, VReg(s1).s4, VReg(2).s4);
+      } else {
+        e.ushl(VReg(d).s4, VReg(s1).s4, VReg(2).s4);
+      }
+      break;
+  }
+  return true;
+}
+
 struct VECTOR_SHL_V128
     : Sequence<VECTOR_SHL_V128, I<OPCODE_VECTOR_SHL, V128Op, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    if (TryEmitConstantVectorShift(e, i.dest, i.src1, i.src2, i.instr->flags,
+                                   0)) {
+      return;
+    }
     int s1 = SrcVReg(e, i.src1, 0);
     int s2 = SrcVReg(e, i.src2, 1);
     int d = i.dest.reg().getIdx();
@@ -714,6 +857,10 @@ EMITTER_OPCODE_TABLE(OPCODE_VECTOR_SHL, VECTOR_SHL_V128);
 struct VECTOR_SHR_V128
     : Sequence<VECTOR_SHR_V128, I<OPCODE_VECTOR_SHR, V128Op, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    if (TryEmitConstantVectorShift(e, i.dest, i.src1, i.src2, i.instr->flags,
+                                   1)) {
+      return;
+    }
     int s1 = SrcVReg(e, i.src1, 0);
     int s2 = SrcVReg(e, i.src2, 1);
     int d = i.dest.reg().getIdx();
@@ -754,6 +901,10 @@ EMITTER_OPCODE_TABLE(OPCODE_VECTOR_SHR, VECTOR_SHR_V128);
 struct VECTOR_SHA_V128
     : Sequence<VECTOR_SHA_V128, I<OPCODE_VECTOR_SHA, V128Op, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    if (TryEmitConstantVectorShift(e, i.dest, i.src1, i.src2, i.instr->flags,
+                                   2)) {
+      return;
+    }
     int s1 = SrcVReg(e, i.src1, 0);
     int s2 = SrcVReg(e, i.src2, 1);
     int d = i.dest.reg().getIdx();
@@ -946,6 +1097,16 @@ struct PERMUTE_I32
       e.ext(VReg(d).b16, VReg(s2).b16, VReg(s3).b16, words[0] * 4);
       return;
     }
+    // vmrghw/vmrglw word interleaves are a single zip: PPC word i is NEON
+    // s[i] directly, so [A0 B0 A1 B1] = zip1 and [A2 B2 A3 B3] = zip2.
+    if (words[0] == 0 && words[1] == 4 && words[2] == 1 && words[3] == 5) {
+      e.zip1(VReg(d).s4, VReg(s2).s4, VReg(s3).s4);
+      return;
+    }
+    if (words[0] == 2 && words[1] == 6 && words[2] == 3 && words[3] == 7) {
+      e.zip2(VReg(d).s4, VReg(s2).s4, VReg(s3).s4);
+      return;
+    }
     // Build TBL control from the I32 permute control word.
     uint8_t tbl_ctrl[16];
     for (int idx = 0; idx < 4; idx++) {
@@ -972,40 +1133,70 @@ struct PERMUTE_V128
                I<OPCODE_PERMUTE, V128Op, V128Op, V128Op, V128Op>> {
   static void EmitByInt8(A64Emitter& e, const EmitArgType& i) {
     int d = i.dest.reg().getIdx();
-    // Copy src2 to v0, src3 to v1 (consecutive for 2-register TBL).
+    // PPC byte order is remapped by byte-reversing each 32-bit word of the
+    // *tables* rather than the control bytes: rev32_table[idx & 0x1F] equals
+    // raw_table[(idx ^ 3) & 0x1F], because ^3 stays inside the 5-bit mask and
+    // never crosses the 16-byte two-register TBL boundary (bit 4 unchanged).
+    // The rev32 doubles as the copy into v0/v1, and constant tables get
+    // their bytes swapped on the host.
+    //
+    // Compute the masked control first: the control register is read before
+    // v0/v1 are written, so no conflict copy is needed.
+    int zip_form = 0;
+    if (i.src1.is_constant) {
+      // Fold the mask on the host too; the adjusted constant is sometimes
+      // movi-encodable, shrinking the load.
+      vec128_t ctrl = i.src1.constant();
+      for (int k = 0; k < 16; k++) {
+        ctrl.u8[k] &= 0x1F;
+      }
+      // The vmrghb/vmrglb byte interleaves collapse to zip1/zip2 on the
+      // rev32'd tables followed by a rev32 of the result, so those controls
+      // skip the control load and the tbl below. Identity checked against
+      // the TBL emission over random vectors.
+      static const vec128_t kMrghbCtrl =
+          vec128b(0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
+      static const vec128_t kMrglbCtrl =
+          vec128b(8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
+      zip_form = (ctrl == kMrghbCtrl) ? 1 : (ctrl == kMrglbCtrl) ? 2 : 0;
+      if (!zip_form) {
+        LoadV128Const(e, 2, ctrl);
+      }
+    } else {
+      e.movi(VReg(2).b16, 0x1F);
+      e.and_(VReg(2).b16, VReg(i.src1.reg().getIdx()).b16, VReg(2).b16);
+    }
     if (i.src2.is_constant) {
-      LoadV128Const(e, 0, i.src2.constant());
-    } else if (i.src2.reg().getIdx() != 0) {
-      e.orr(VReg(0).b16, VReg(i.src2.reg().getIdx()).b16,
-            VReg(i.src2.reg().getIdx()).b16);
+      vec128_t t = i.src2.constant();
+      vec128_t swapped;
+      for (int k = 0; k < 16; k++) {
+        swapped.u8[k] = t.u8[k ^ 3];
+      }
+      LoadV128Const(e, 0, swapped);
+    } else {
+      e.rev32(VReg(0).b16, VReg(i.src2.reg().getIdx()).b16);
     }
     if (i.src3.is_constant) {
-      LoadV128Const(e, 1, i.src3.constant());
-    } else if (i.src3.reg().getIdx() != 1) {
-      e.orr(VReg(1).b16, VReg(i.src3.reg().getIdx()).b16,
-            VReg(i.src3.reg().getIdx()).b16);
-    }
-    // Load control vector into v2, XOR each byte with 3 for endian swap.
-    int ctrl;
-    if (i.src1.is_constant) {
-      LoadV128Const(e, 2, i.src1.constant());
-      ctrl = 2;
-    } else {
-      ctrl = i.src1.reg().getIdx();
-      if (ctrl == 0 || ctrl == 1) {
-        // Control conflicts with table registers, copy to v2.
-        e.orr(VReg(2).b16, VReg(ctrl).b16, VReg(ctrl).b16);
-        ctrl = 2;
+      vec128_t t = i.src3.constant();
+      vec128_t swapped;
+      for (int k = 0; k < 16; k++) {
+        swapped.u8[k] = t.u8[k ^ 3];
       }
+      LoadV128Const(e, 1, swapped);
+    } else {
+      e.rev32(VReg(1).b16, VReg(i.src3.reg().getIdx()).b16);
     }
-    // XOR control bytes with 0x03 to remap PPC byte indices to LE,
-    // then mask to 5 bits (0-31) so TBL indices stay in range.
-    e.movi(VReg(3).b16, 0x03);
-    e.eor(VReg(3).b16, VReg(ctrl).b16, VReg(3).b16);
-    e.movi(VReg(2).b16, 0x1F);
-    e.and_(VReg(3).b16, VReg(3).b16, VReg(2).b16);
+    if (zip_form) {
+      if (zip_form == 1) {
+        e.zip1(VReg(d).b16, VReg(0).b16, VReg(1).b16);
+      } else {
+        e.zip2(VReg(d).b16, VReg(0).b16, VReg(1).b16);
+      }
+      e.rev32(VReg(d).b16, VReg(d).b16);
+      return;
+    }
     // TBL with 2-register table {v0, v1}.
-    e.tbl(VReg(d).b16, VReg(0).b16, 2, VReg(3).b16);
+    e.tbl(VReg(d).b16, VReg(0).b16, 2, VReg(2).b16);
   }
 
   static void EmitByInt16(A64Emitter& e, const EmitArgType& i) {
@@ -1015,6 +1206,30 @@ struct PERMUTE_V128
     // PPC halfword index H maps to NEON u16 index (H&7)^1 (halfword swap
     // within 32-bit words). For src3 (indices >= 8), add 16 byte offset.
     vec128_t ctrl = i.src1.constant();
+    // The vmrghh/vmrglh halfword interleaves - the only INT16 permutes the
+    // frontend emits - are one zip plus a word swap: zip1/zip2 on the
+    // halfword-swapped layout interleaves the wrong pair order within each
+    // word, and rev64.4s swaps the adjacent words back. Identity checked
+    // against the TBL emission over random vectors.
+    {
+      static const vec128_t kMrghhCtrl = vec128s(0, 8, 1, 9, 2, 10, 3, 11);
+      static const vec128_t kMrglhCtrl = vec128s(4, 12, 5, 13, 6, 14, 7, 15);
+      vec128_t masked = ctrl;
+      for (int k = 0; k < 8; k++) {
+        masked.u16[k] &= 0xF;
+      }
+      if (masked == kMrghhCtrl || masked == kMrglhCtrl) {
+        int a = SrcVReg(e, i.src2, 0);
+        int b = SrcVReg(e, i.src3, 1);
+        if (masked == kMrghhCtrl) {
+          e.zip1(VReg(d).h8, VReg(b).h8, VReg(a).h8);
+        } else {
+          e.zip2(VReg(d).h8, VReg(b).h8, VReg(a).h8);
+        }
+        e.rev64(VReg(d).s4, VReg(d).s4);
+        return;
+      }
+    }
     vec128_t tbl_ctrl = {};
     for (int k = 0; k < 8; k++) {
       uint16_t h = ctrl.u16[k] & 0xF;
@@ -1179,6 +1394,18 @@ EMITTER_OPCODE_TABLE(OPCODE_LOAD_VECTOR_SHR, LOAD_VECTOR_SHR_I8);
 // ============================================================================
 // OPCODE_PACK
 // ============================================================================
+// FMAXNM/FMINNM return the other operand only for a *quiet* NaN. A signalling
+// NaN propagates as a NaN instead, so the clamp below lets it through and the
+// following FMINNM then picks the wrong end of the range. x86 MAXPS/MINPS
+// return the second operand for any NaN, which is what these PACK sequences
+// rely on ("pack NaN as zero"; titles depend on the order).
+//
+// FMAXNM(x, x) is the identity for every input except a signalling NaN, which
+// it quiets, so one instruction makes the two backends agree.
+static void EmitQuietSnan(A64Emitter& e, int d, int s) {
+  e.fmaxnm(VReg(d).s4, VReg(s).s4, VReg(s).s4);
+}
+
 struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
     switch (i.instr->flags & hir::PACK_TYPE_MODE) {
@@ -1219,9 +1446,10 @@ struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
     int s = SrcVReg(e, i.src1, 2);
     int d = i.dest.reg().getIdx();
     // Clamp to [3.0f, 3.0f + 255*2^-22].
-    // fmaxnm/fminnm: NaN operand returns the non-NaN value (pack NaN as zero).
+    // Quiet first, then clamp: NaN packs as zero (see EmitQuietSnan).
     e.fmov(VReg(0).s4, 3.0f);
-    e.fmaxnm(VReg(d).s4, VReg(s).s4, VReg(0).s4);
+    EmitQuietSnan(e, d, s);
+    e.fmaxnm(VReg(d).s4, VReg(d).s4, VReg(0).s4);
     LoadV128Const(e, 0, vec128i(0x404000FFu));  // 3.0f + 255*2^-22
     e.fminnm(VReg(d).s4, VReg(d).s4, VReg(0).s4);
     // TBL: extract low byte from each lane, reorder RGBA->ARGB in lane 3.
@@ -1238,7 +1466,8 @@ struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
     int d = i.dest.reg().getIdx();
     // Clamp to [PackSHORT_Min, PackSHORT_Max].
     LoadV128Const(e, 0, vec128i(0x403F8001u));
-    e.fmaxnm(VReg(d).s4, VReg(s).s4, VReg(0).s4);
+    EmitQuietSnan(e, d, s);
+    e.fmaxnm(VReg(d).s4, VReg(d).s4, VReg(0).s4);
     LoadV128Const(e, 0, vec128i(0x40407FFFu));
     e.fminnm(VReg(d).s4, VReg(d).s4, VReg(0).s4);
     // TBL: extract low 2 bytes from lanes 0,1 -> pack into lane 3.
@@ -1254,7 +1483,8 @@ struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
     int s = SrcVReg(e, i.src1, 2);
     int d = i.dest.reg().getIdx();
     LoadV128Const(e, 0, vec128i(0x403F8001u));
-    e.fmaxnm(VReg(d).s4, VReg(s).s4, VReg(0).s4);
+    EmitQuietSnan(e, d, s);
+    e.fmaxnm(VReg(d).s4, VReg(d).s4, VReg(0).s4);
     LoadV128Const(e, 0, vec128i(0x40407FFFu));
     e.fminnm(VReg(d).s4, VReg(d).s4, VReg(0).s4);
     // TBL ctrl for PACK_SHORT_4: bytes 8-11={0x04,0x05,0x00,0x01},
@@ -1371,14 +1601,15 @@ struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
     int d = i.dest.reg().getIdx();
 
     // Clamp to valid range: fmaxnm(src, min) then fminnm(result, max).
-    // fmaxnm clamps NaN to min (NaN packs as the minimum value).
+    // Quiet first, so a signalling NaN also clamps to min.
     // XYZ min=0x403FFE01 (-511), max=0x404001FF (+511)
     // W   min=0x40400000 (0),    max=0x40400003 (+3)
     e.mov(e.x0, 0x403FFE01403FFE01ull);
     e.fmov(DReg(0), e.x0);
     e.mov(e.x0, 0x40400000403FFE01ull);
     e.ins(VReg(0).d2[1], e.x0);
-    e.fmaxnm(VReg(d).s4, VReg(s).s4, VReg(0).s4);
+    EmitQuietSnan(e, d, s);
+    e.fmaxnm(VReg(d).s4, VReg(d).s4, VReg(0).s4);
 
     e.mov(e.x0, 0x404001FF404001FFull);
     e.fmov(DReg(0), e.x0);
@@ -1420,7 +1651,8 @@ struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
     e.fmov(DReg(0), e.x0);
     e.mov(e.x0, 0x4040000040380001ull);
     e.ins(VReg(0).d2[1], e.x0);
-    e.fmaxnm(VReg(d).s4, VReg(s).s4, VReg(0).s4);
+    EmitQuietSnan(e, d, s);
+    e.fmaxnm(VReg(d).s4, VReg(d).s4, VReg(0).s4);
 
     e.mov(e.x0, 0x4047FFFF4047FFFFull);
     e.fmov(DReg(0), e.x0);

--- a/src/xenia/cpu/backend/a64/a64_sequences.cc
+++ b/src/xenia/cpu/backend/a64/a64_sequences.cc
@@ -239,6 +239,23 @@ struct LOAD_CONTEXT_I64
     : Sequence<LOAD_CONTEXT_I64, I<OPCODE_LOAD_CONTEXT, I64Op, OffsetOp>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
     auto offset = static_cast<uint32_t>(i.src1.value);
+    // Every blr/bctr is a single-use LOAD_CONTEXT of lr/ctr feeding the very
+    // next CALL_INDIRECT, whose thunk contract wants the target in w16 (the
+    // allocator can never satisfy that itself: w16 is outside the register
+    // map). Load w16 directly and skip the allocated dest entirely; the
+    // call reads only the low 32 bits of the target.
+    const hir::Instr* next = i.instr->next;
+    const bool single_use =
+        i.instr->dest->use_head && !i.instr->dest->use_head->next;
+    if (single_use && next &&
+        ((next->GetOpcodeNum() == OPCODE_CALL_INDIRECT &&
+          next->src1.value == i.instr->dest) ||
+         (next->GetOpcodeNum() == OPCODE_CALL_INDIRECT_TRUE &&
+          next->src2.value == i.instr->dest))) {
+      e.ldr(e.w16, ptr(e.GetContextReg(), offset));
+      e.DeclareW16Holds(i.instr->dest);
+      return;
+    }
     e.ldr(i.dest, ptr(e.GetContextReg(), offset));
   }
 };
@@ -575,20 +592,68 @@ struct ADD_I64 : Sequence<ADD_I64, I<OPCODE_ADD, I64Op, I64Op, I64Op>> {
 // operand needs nothing: ARM's default NaN is the one PPC produces.
 enum class FpBinOp { Add, Sub, Mul, Div };
 
+// Emits the hardware op and tests only its result: any NaN input propagates
+// to a NaN result, so one fcmp on dest replaces the two-operand screen. The
+// positional-NaN slow path sits in the function tail when the near-branch
+// bound allows, inline otherwise. NaN results are never canonicalised: a NaN
+// result with no NaN operand is an invalid operation, and dest already holds
+// the hardware default QNaN, which is PPC's (see the FPCR.DN invariant at
+// DEFAULT_FPU_FPCR).
 static void EmitFpBinOpWithPpcNan_F32(A64Emitter& e, SReg dest, SReg s1,
                                       SReg s2, FpBinOp op) {
-  // Ensure FPU FPCR (no flush-to-zero) for scalar operations.
   e.ChangeFpcrMode(FPCRMode::Fpu);
-  auto& nan_path = e.NewCachedLabel();
   auto& done = e.NewCachedLabel();
 
-  // Check if either input is NaN. fccmp sets NZCV from immediate if the
-  // condition is false (i.e. s1 was already NaN), preserving V=1.
-  e.fcmp(s1, s1);
-  e.fccmp(s2, s2, 0b0001, VC);
-  e.b_near(VS, nan_path);
+  // Result-gated: the hardware op runs first and only its result is tested -
+  // any NaN input propagates to a NaN result. When dest aliases a source the
+  // slow path still needs the original value, preserved in scratch up front
+  // (a constant source already lives in scratch and cannot alias).
+  SReg t1 = s1;
+  SReg t2 = s2;
+  if (dest.getIdx() == s1.getIdx()) {
+    e.fmov(e.s2, s1);
+    t1 = e.s2;
+  }
+  if (dest.getIdx() == s2.getIdx()) {
+    if (s2.getIdx() == s1.getIdx()) {
+      t2 = t1;
+    } else {
+      e.fmov(e.s3, s2);
+      t2 = e.s3;
+    }
+  }
 
-  // Fast path: no NaN input — hardware op.
+  // Slow path: first NaN by position wins, quiet if SNaN. If neither operand
+  // is NaN, the result's NaN came from an invalid operation and dest already
+  // holds the hardware default QNaN, which is PPC's - leave it.
+  auto emit_nan_walk = [dest, t1, t2, &done](A64Emitter& e) {
+    auto& s1_not_nan = e.NewCachedLabel();
+    e.fcmp(t1, t1);
+    e.b_near(VC, s1_not_nan);
+    e.fmov(e.w0, t1);
+    e.orr(e.w0, e.w0, static_cast<uint64_t>(1u << 22));
+    e.fmov(dest, e.w0);
+    e.b(done);
+    e.L(s1_not_nan);
+    e.fcmp(t2, t2);
+    e.b_near(VC, done);
+    e.fmov(e.w0, t2);
+    e.orr(e.w0, e.w0, static_cast<uint64_t>(1u << 22));
+    e.fmov(dest, e.w0);
+    e.b(done);
+  };
+
+  const bool tail_ok = e.near_tail_branches_safe();
+  Xbyak_aarch64::Label* nan_path;
+  if (tail_ok) {
+    nan_path =
+        &e.AddToTail([emit_nan_walk](A64Emitter& e, Xbyak_aarch64::Label&) {
+          emit_nan_walk(e);
+        });
+  } else {
+    nan_path = &e.NewCachedLabel();
+  }
+
   switch (op) {
     case FpBinOp::Add:
       e.fadd(dest, s1, s2);
@@ -603,38 +668,73 @@ static void EmitFpBinOpWithPpcNan_F32(A64Emitter& e, SReg dest, SReg s1,
       e.fdiv(dest, s1, s2);
       break;
   }
-  e.b(done);
-
-  // Slow path: first NaN by position wins, quiet if SNaN.
-  e.L(nan_path);
-  auto& s1_not_nan = e.NewCachedLabel();
-  e.fcmp(s1, s1);
-  e.b_near(VC, s1_not_nan);
-  e.fmov(e.w0, s1);
-  e.orr(e.w0, e.w0, static_cast<uint64_t>(1u << 22));
-  e.fmov(dest, e.w0);
-  e.b(done);
-  e.L(s1_not_nan);
-  e.fmov(e.w0, s2);
-  e.orr(e.w0, e.w0, static_cast<uint64_t>(1u << 22));
-  e.fmov(dest, e.w0);
-
+  e.fcmp(dest, dest);
+  e.b_near(VS, *nan_path);
+  if (!tail_ok) {
+    e.b(done);
+    e.L(*nan_path);
+    emit_nan_walk(e);
+  }
   e.L(done);
 }
 
+// See the F32 twin for the layout and the no-canonicalisation rationale (the
+// F64 default QNaN 0x7FF8000000000000 is likewise what hardware produces).
 static void EmitFpBinOpWithPpcNan_F64(A64Emitter& e, DReg dest, DReg s1,
                                       DReg s2, FpBinOp op) {
   e.ChangeFpcrMode(FPCRMode::Fpu);
-  auto& nan_path = e.NewCachedLabel();
   auto& done = e.NewCachedLabel();
 
-  // Check if either input is NaN. fccmp sets NZCV from immediate if the
-  // condition is false (i.e. s1 was already NaN), preserving V=1.
-  e.fcmp(s1, s1);
-  e.fccmp(s2, s2, 0b0001, VC);
-  e.b_near(VS, nan_path);
+  // Result-gated: the hardware op runs first and only its result is tested -
+  // any NaN input propagates to a NaN result. When dest aliases a source the
+  // slow path still needs the original value, preserved in scratch up front
+  // (a constant source already lives in scratch and cannot alias).
+  DReg t1 = s1;
+  DReg t2 = s2;
+  if (dest.getIdx() == s1.getIdx()) {
+    e.fmov(e.d2, s1);
+    t1 = e.d2;
+  }
+  if (dest.getIdx() == s2.getIdx()) {
+    if (s2.getIdx() == s1.getIdx()) {
+      t2 = t1;
+    } else {
+      e.fmov(e.d3, s2);
+      t2 = e.d3;
+    }
+  }
 
-  // Fast path: no NaN input — hardware op.
+  // Slow path: first NaN by position wins, quiet if SNaN. If neither operand
+  // is NaN, the result's NaN came from an invalid operation and dest already
+  // holds the hardware default QNaN, which is PPC's - leave it.
+  auto emit_nan_walk = [dest, t1, t2, &done](A64Emitter& e) {
+    auto& s1_not_nan = e.NewCachedLabel();
+    e.fcmp(t1, t1);
+    e.b_near(VC, s1_not_nan);
+    e.fmov(e.x0, t1);
+    e.orr(e.x0, e.x0, static_cast<uint64_t>(1ull << 51));
+    e.fmov(dest, e.x0);
+    e.b(done);
+    e.L(s1_not_nan);
+    e.fcmp(t2, t2);
+    e.b_near(VC, done);
+    e.fmov(e.x0, t2);
+    e.orr(e.x0, e.x0, static_cast<uint64_t>(1ull << 51));
+    e.fmov(dest, e.x0);
+    e.b(done);
+  };
+
+  const bool tail_ok = e.near_tail_branches_safe();
+  Xbyak_aarch64::Label* nan_path;
+  if (tail_ok) {
+    nan_path =
+        &e.AddToTail([emit_nan_walk](A64Emitter& e, Xbyak_aarch64::Label&) {
+          emit_nan_walk(e);
+        });
+  } else {
+    nan_path = &e.NewCachedLabel();
+  }
+
   switch (op) {
     case FpBinOp::Add:
       e.fadd(dest, s1, s2);
@@ -649,24 +749,16 @@ static void EmitFpBinOpWithPpcNan_F64(A64Emitter& e, DReg dest, DReg s1,
       e.fdiv(dest, s1, s2);
       break;
   }
-  e.b(done);
-
-  // Slow path: first NaN by position wins, quiet if SNaN.
-  e.L(nan_path);
-  auto& s1_not_nan = e.NewCachedLabel();
-  e.fcmp(s1, s1);
-  e.b_near(VC, s1_not_nan);
-  e.fmov(e.x0, s1);
-  e.orr(e.x0, e.x0, static_cast<uint64_t>(1ull << 51));
-  e.fmov(dest, e.x0);
-  e.b(done);
-  e.L(s1_not_nan);
-  e.fmov(e.x0, s2);
-  e.orr(e.x0, e.x0, static_cast<uint64_t>(1ull << 51));
-  e.fmov(dest, e.x0);
-
+  e.fcmp(dest, dest);
+  e.b_near(VS, *nan_path);
+  if (!tail_ok) {
+    e.b(done);
+    e.L(*nan_path);
+    emit_nan_walk(e);
+  }
   e.L(done);
 }
+
 // PPC FMA NaN selection (PowerISA 4.6.7.2):
 // The first NaN operand by position (frA=s1, frC=s2, frB=s3) wins,
 // regardless of QNaN vs SNaN.  If it's an SNaN, quiet it (set the
@@ -681,101 +773,155 @@ static void EmitFpBinOpWithPpcNan_F64(A64Emitter& e, DReg dest, DReg s1,
 static void EmitFmaWithPpcNan_F64(A64Emitter& e, DReg dest, DReg s1, DReg s2,
                                   DReg s3, bool is_sub, bool negate) {
   e.ChangeFpcrMode(FPCRMode::Fpu);
-  auto& nan_path = e.NewCachedLabel();
   auto& done = e.NewCachedLabel();
 
-  // Quick check: any NaN among the three operands?
-  e.fcmp(s1, s1);
-  e.fccmp(s2, s2, 0b0001, VC);
-  e.fccmp(s3, s3, 0b0001, VC);
-  e.b_near(VS, nan_path);
+  // Result-gated: the hardware FMA runs first and one fcmp on dest replaces
+  // the three-operand screen, since any NaN input propagates to the result.
+  // The slow path walks the operands in A, B, C order (HIR order is
+  // (A, C, B), so s1, s3, s2), takes the first NaN quieted, and if none is
+  // NaN leaves dest alone: the result NaN was generated (0*inf, inf-inf)
+  // and dest already holds the hardware default QNaN, which is PPC's. It
+  // sits in the function tail when the near-branch bound allows, inline
+  // otherwise, and every exit rejoins below the fneg, so NaNs are never
+  // negated.
+  // When dest aliases a source (reachable for non-Rc double forms via
+  // allocator eviction) the aliased value is preserved in v3 - the one
+  // vector scratch the call sites leave free - before the FMA overwrites
+  // it. The walk reads only the preserved operands, never dest: ARM FNMSUB
+  // negates the addend before the fused op, so a NaN addend can reach dest
+  // sign-flipped.
+  DReg t1 = s1;
+  DReg t2 = s2;
+  DReg t3 = s3;
+  if (dest.getIdx() == s1.getIdx() || dest.getIdx() == s2.getIdx() ||
+      dest.getIdx() == s3.getIdx()) {
+    const DReg preserved = DReg(3);
+    e.fmov(preserved, dest);
+    if (s1.getIdx() == dest.getIdx()) {
+      t1 = preserved;
+    }
+    if (s2.getIdx() == dest.getIdx()) {
+      t2 = preserved;
+    }
+    if (s3.getIdx() == dest.getIdx()) {
+      t3 = preserved;
+    }
+  }
+  auto emit_nan_walk = [dest, t1, t2, t3, &done](A64Emitter& e) {
+    DReg order[3] = {t1, t3, t2};
+    for (int step = 0; step < 3; ++step) {
+      auto& not_nan = e.NewCachedLabel();
+      e.fcmp(order[step], order[step]);
+      e.b_near(VC, not_nan);
+      e.fmov(e.x0, order[step]);
+      e.orr(e.x0, e.x0, static_cast<uint64_t>(1ull << 51));  // ensure quiet
+      e.fmov(dest, e.x0);
+      e.b(done);
+      e.L(not_nan);
+    }
+    // No operand NaN: generated NaN, and dest already holds the PPC default
+    // QNaN (see DEFAULT_FPU_FPCR). Leave it.
+    e.b(done);
+  };
+  const bool tail_ok = e.near_tail_branches_safe();
+  Xbyak_aarch64::Label* nan_path;
+  if (tail_ok) {
+    nan_path =
+        &e.AddToTail([emit_nan_walk](A64Emitter& e, Xbyak_aarch64::Label&) {
+          emit_nan_walk(e);
+        });
+  } else {
+    nan_path = &e.NewCachedLabel();
+  }
 
-  // Fast path: no NaN input → hardware FMA, then negate the result. Not
-  // fnmadd: that negates the operands (-Ra - Rn*Rm), which differs from
+  // Not fnmadd: that negates the operands (-Ra - Rn*Rm), which differs from
   // -(Ra + Rn*Rm) when the two addends are zeros of opposite sign.
-  auto& invalid = e.NewCachedLabel();
   if (is_sub) {
     e.fnmsub(dest, s1, s2, s3);
   } else {
     e.fmadd(dest, s1, s2, s3);
   }
-  // If result is NaN (0*inf or inf-inf), canonicalize to PPC default.
   e.fcmp(dest, dest);
-  e.b_near(VS, invalid);
+  e.b_near(VS, *nan_path);
+  // Numeric results only: every NaN took the branch above.
   if (negate) {
     e.fneg(dest, dest);
   }
-  e.b(done);
-  e.L(invalid);
-  e.mov(e.x0, static_cast<uint64_t>(0x7FF8000000000000ull));
-  e.fmov(dest, e.x0);
-  e.b(done);
-
-  // Slow path: first NaN in A, B, C order wins (quiet if SNaN).
-  e.L(nan_path);
-  DReg order[3] = {s1, s3, s2};
-  for (int step = 0; step < 2; ++step) {
-    auto& not_nan = e.NewCachedLabel();
-    e.fcmp(order[step], order[step]);
-    e.b_near(VC, not_nan);
-    e.fmov(e.x0, order[step]);
-    e.orr(e.x0, e.x0, static_cast<uint64_t>(1ull << 51));  // ensure quiet
-    e.fmov(dest, e.x0);
+  if (!tail_ok) {
     e.b(done);
-    e.L(not_nan);
+    e.L(*nan_path);
+    emit_nan_walk(e);
   }
-  // At least one operand is a NaN, so it must be this one.
-  e.fmov(e.x0, order[2]);
-  e.orr(e.x0, e.x0, static_cast<uint64_t>(1ull << 51));
-  e.fmov(dest, e.x0);
-
   e.L(done);
 }
 
 static void EmitFmaWithPpcNan_F32(A64Emitter& e, SReg dest, SReg s1, SReg s2,
                                   SReg s3, bool is_sub, bool negate) {
   e.ChangeFpcrMode(FPCRMode::Fpu);
-  auto& nan_path = e.NewCachedLabel();
   auto& done = e.NewCachedLabel();
 
-  e.fcmp(s1, s1);
-  e.fccmp(s2, s2, 0b0001, VC);
-  e.fccmp(s3, s3, 0b0001, VC);
-  e.b_near(VS, nan_path);
+  // See the F64 twin for the layout, including why an aliased dest is
+  // preserved in v3 before the FMA.
+  SReg t1 = s1;
+  SReg t2 = s2;
+  SReg t3 = s3;
+  if (dest.getIdx() == s1.getIdx() || dest.getIdx() == s2.getIdx() ||
+      dest.getIdx() == s3.getIdx()) {
+    const SReg preserved = SReg(3);
+    e.fmov(preserved, dest);
+    if (s1.getIdx() == dest.getIdx()) {
+      t1 = preserved;
+    }
+    if (s2.getIdx() == dest.getIdx()) {
+      t2 = preserved;
+    }
+    if (s3.getIdx() == dest.getIdx()) {
+      t3 = preserved;
+    }
+  }
+  auto emit_nan_walk = [dest, t1, t2, t3, &done](A64Emitter& e) {
+    SReg order[3] = {t1, t3, t2};
+    for (int step = 0; step < 3; ++step) {
+      auto& not_nan = e.NewCachedLabel();
+      e.fcmp(order[step], order[step]);
+      e.b_near(VC, not_nan);
+      e.fmov(e.w0, order[step]);
+      e.orr(e.w0, e.w0, static_cast<uint32_t>(1u << 22));
+      e.fmov(dest, e.w0);
+      e.b(done);
+      e.L(not_nan);
+    }
+    // No operand NaN: generated NaN, and dest already holds the PPC default
+    // QNaN (see DEFAULT_FPU_FPCR). Leave it.
+    e.b(done);
+  };
+  const bool tail_ok = e.near_tail_branches_safe();
+  Xbyak_aarch64::Label* nan_path;
+  if (tail_ok) {
+    nan_path =
+        &e.AddToTail([emit_nan_walk](A64Emitter& e, Xbyak_aarch64::Label&) {
+          emit_nan_walk(e);
+        });
+  } else {
+    nan_path = &e.NewCachedLabel();
+  }
 
-  auto& invalid = e.NewCachedLabel();
+  // See the F64 twin: result-gated, negation runs only on numeric results.
   if (is_sub) {
     e.fnmsub(dest, s1, s2, s3);
   } else {
     e.fmadd(dest, s1, s2, s3);
   }
   e.fcmp(dest, dest);
-  e.b_near(VS, invalid);
+  e.b_near(VS, *nan_path);
   if (negate) {
     e.fneg(dest, dest);
   }
-  e.b(done);
-  e.L(invalid);
-  e.mov(e.w0, static_cast<uint64_t>(0x7FC00000u));
-  e.fmov(dest, e.w0);
-  e.b(done);
-
-  e.L(nan_path);
-  SReg order[3] = {s1, s3, s2};
-  for (int step = 0; step < 2; ++step) {
-    auto& not_nan = e.NewCachedLabel();
-    e.fcmp(order[step], order[step]);
-    e.b_near(VC, not_nan);
-    e.fmov(e.w0, order[step]);
-    e.orr(e.w0, e.w0, static_cast<uint32_t>(1u << 22));
-    e.fmov(dest, e.w0);
+  if (!tail_ok) {
     e.b(done);
-    e.L(not_nan);
+    e.L(*nan_path);
+    emit_nan_walk(e);
   }
-  e.fmov(e.w0, order[2]);
-  e.orr(e.w0, e.w0, static_cast<uint32_t>(1u << 22));
-  e.fmov(dest, e.w0);
-
   e.L(done);
 }
 
@@ -1615,17 +1761,32 @@ EMITTER_OPCODE_TABLE(OPCODE_ABS, ABS_F32, ABS_F64, ABS_V128);
 // OPCODE_AND
 // ============================================================================
 struct AND_I8 : Sequence<AND_I8, I<OPCODE_AND, I8Op, I8Op, I8Op>> {
+  static void EmitAndsImm(A64Emitter& e, const WReg& dest, const WReg& src,
+                          uint32_t imm) {
+    if (IsValidLogicalImm(imm, 32)) {
+      e.ands(dest, src, imm);
+    } else {
+      e.mov(e.w0, static_cast<uint64_t>(imm));  // mov leaves NZCV alone
+      e.ands(dest, src, e.w0);
+    }
+  }
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // ANDS instead of AND: I8 values are zero-extended in their W registers,
+    // so the 32-bit Z flag equals the I8 zero test, and a following
+    // compare-vs-zero or select can skip its cmp. Same pattern as AND_I32/64.
     if (i.src1.is_constant && i.src2.is_constant) {
       e.mov(i.dest, static_cast<uint64_t>(
                         (i.src1.constant() & i.src2.constant()) & 0xFF));
-    } else if (i.src2.is_constant) {
-      e.and_imm(i.dest, i.src1, i.src2.constant() & 0xFF, e.w0);
-    } else if (i.src1.is_constant) {
-      e.and_imm(i.dest, i.src2, i.src1.constant() & 0xFF, e.w0);
-    } else {
-      e.and_(i.dest, i.src1, i.src2);
+      return;
     }
+    if (i.src2.is_constant) {
+      EmitAndsImm(e, i.dest, i.src1, i.src2.constant() & 0xFF);
+    } else if (i.src1.is_constant) {
+      EmitAndsImm(e, i.dest, i.src2, i.src1.constant() & 0xFF);
+    } else {
+      e.ands(i.dest, i.src1, i.src2);
+    }
+    e.DeclareFlagsZeroTest(i.dest.reg().getIdx(), false);
   }
 };
 struct AND_I16 : Sequence<AND_I16, I<OPCODE_AND, I16Op, I16Op, I16Op>> {
@@ -1643,40 +1804,59 @@ struct AND_I16 : Sequence<AND_I16, I<OPCODE_AND, I16Op, I16Op, I16Op>> {
   }
 };
 struct AND_I32 : Sequence<AND_I32, I<OPCODE_AND, I32Op, I32Op, I32Op>> {
+  static void EmitAndsImm(A64Emitter& e, const WReg& dest, const WReg& src,
+                          uint32_t imm) {
+    if (IsValidLogicalImm(imm, 32)) {
+      e.ands(dest, src, imm);
+    } else {
+      e.mov(e.w0, static_cast<uint64_t>(imm));  // mov leaves NZCV alone
+      e.ands(dest, src, e.w0);
+    }
+  }
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // ANDS instead of AND costs nothing and lets an immediately following
+    // compare-vs-zero of this dest drop its cmp (the hot
+    // IsFalse(And(x, mask)) pattern in the FPSCR derivation).
     if (i.src1.is_constant && i.src2.is_constant) {
       e.mov(i.dest, static_cast<uint64_t>(static_cast<uint32_t>(
                         i.src1.constant() & i.src2.constant())));
-    } else if (i.src2.is_constant) {
-      e.and_imm(i.dest, i.src1, static_cast<uint32_t>(i.src2.constant()), e.w0);
-    } else if (i.src1.is_constant) {
-      e.and_imm(i.dest, i.src2, static_cast<uint32_t>(i.src1.constant()), e.w0);
-    } else {
-      e.and_(i.dest, i.src1, i.src2);
+      return;
     }
+    if (i.src2.is_constant) {
+      EmitAndsImm(e, i.dest, i.src1, static_cast<uint32_t>(i.src2.constant()));
+    } else if (i.src1.is_constant) {
+      EmitAndsImm(e, i.dest, i.src2, static_cast<uint32_t>(i.src1.constant()));
+    } else {
+      e.ands(i.dest, i.src1, i.src2);
+    }
+    e.DeclareFlagsZeroTest(i.dest.reg().getIdx(), false);
   }
 };
 struct AND_I64 : Sequence<AND_I64, I<OPCODE_AND, I64Op, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // See AND_I32: ANDS is free and feeds the compare-vs-zero fusion.
     if (i.src1.is_constant && i.src2.is_constant) {
       e.mov(i.dest,
             static_cast<uint64_t>(i.src1.constant() & i.src2.constant()));
-    } else if (i.src2.is_constant) {
-      EmitAndImm(e, i.dest, i.src1, static_cast<uint64_t>(i.src2.constant()));
-    } else if (i.src1.is_constant) {
-      EmitAndImm(e, i.dest, i.src2, static_cast<uint64_t>(i.src1.constant()));
-    } else {
-      e.and_(i.dest, i.src1, i.src2);
+      return;
     }
+    if (i.src2.is_constant) {
+      EmitAndsImm(e, i.dest, i.src1, static_cast<uint64_t>(i.src2.constant()));
+    } else if (i.src1.is_constant) {
+      EmitAndsImm(e, i.dest, i.src2, static_cast<uint64_t>(i.src1.constant()));
+    } else {
+      e.ands(i.dest, i.src1, i.src2);
+    }
+    e.DeclareFlagsZeroTest(i.dest.reg().getIdx(), true);
   }
 
-  static void EmitAndImm(A64Emitter& e, const XReg& dest, const XReg& src,
-                         uint64_t imm) {
+  static void EmitAndsImm(A64Emitter& e, const XReg& dest, const XReg& src,
+                          uint64_t imm) {
     if (IsValidLogicalImm(imm, 64)) {
-      e.and_(dest, src, imm);
+      e.ands(dest, src, imm);
     } else {
-      e.mov(e.x0, imm);
-      e.and_(dest, src, e.x0);
+      e.mov(e.x0, imm);  // mov leaves NZCV alone
+      e.ands(dest, src, e.x0);
     }
   }
 };
@@ -2017,16 +2197,23 @@ struct SHL_I8 : Sequence<SHL_I8, I<OPCODE_SHL, I8Op, I8Op, I8Op>> {
         e.uxtb(i.dest, i.dest);
       }
     } else {
-      // Read shift amount first — dest may alias src2.
-      e.mov(e.w0, i.src2);
-      if (i.src1.is_constant) {
-        e.mov(i.dest, static_cast<uint64_t>(i.src1.constant() & 0xFF));
-      } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
-        e.mov(i.dest, i.src1);
+      // LSLV/LSRV/ASRV read both sources before writing dest, so a
+      // register amount needs no staging copy even when dest aliases it.
+      if (!i.src1.is_constant) {
+        e.lsl(i.dest, i.src1, WReg(i.src2.reg().getIdx()));
+        e.uxtb(i.dest, i.dest);
+      } else {
+        // Read shift amount first — dest may alias src2.
+        e.mov(e.w0, i.src2);
+        if (i.src1.is_constant) {
+          e.mov(i.dest, static_cast<uint64_t>(i.src1.constant() & 0xFF));
+        } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
+          e.mov(i.dest, i.src1);
+        }
+        e.lsl(i.dest, i.dest, e.w0);
+        // Bits can shift past the type width; keep the I8 value zero-extended.
+        e.uxtb(i.dest, i.dest);
       }
-      e.lsl(i.dest, i.dest, e.w0);
-      // Bits can shift past the type width; keep the I8 value zero-extended.
-      e.uxtb(i.dest, i.dest);
     }
   }
 };
@@ -2048,16 +2235,23 @@ struct SHL_I16 : Sequence<SHL_I16, I<OPCODE_SHL, I16Op, I16Op, I8Op>> {
         e.uxth(i.dest, i.dest);
       }
     } else {
-      // Read shift amount first — dest may alias src2.
-      e.mov(e.w0, i.src2);
-      if (i.src1.is_constant) {
-        e.mov(i.dest, static_cast<uint64_t>(i.src1.constant() & 0xFFFF));
-      } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
-        e.mov(i.dest, i.src1);
+      // LSLV/LSRV/ASRV read both sources before writing dest, so a
+      // register amount needs no staging copy even when dest aliases it.
+      if (!i.src1.is_constant) {
+        e.lsl(i.dest, i.src1, WReg(i.src2.reg().getIdx()));
+        e.uxth(i.dest, i.dest);
+      } else {
+        // Read shift amount first — dest may alias src2.
+        e.mov(e.w0, i.src2);
+        if (i.src1.is_constant) {
+          e.mov(i.dest, static_cast<uint64_t>(i.src1.constant() & 0xFFFF));
+        } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
+          e.mov(i.dest, i.src1);
+        }
+        e.lsl(i.dest, i.dest, e.w0);
+        // Bits can shift past the type width; keep the I16 value zero-extended.
+        e.uxth(i.dest, i.dest);
       }
-      e.lsl(i.dest, i.dest, e.w0);
-      // Bits can shift past the type width; keep the I16 value zero-extended.
-      e.uxth(i.dest, i.dest);
     }
   }
 };
@@ -2071,15 +2265,21 @@ struct SHL_I32 : Sequence<SHL_I32, I<OPCODE_SHL, I32Op, I32Op, I8Op>> {
         e.lsl(i.dest, i.src1, static_cast<uint32_t>(i.src2.constant() & 0x1F));
       }
     } else {
-      // Read shift amount first — dest may alias src2.
-      e.mov(e.w0, i.src2);
-      if (i.src1.is_constant) {
-        e.mov(i.dest,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
-      } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
-        e.mov(i.dest, i.src1);
+      // LSLV/LSRV/ASRV read both sources before writing dest, so a
+      // register amount needs no staging copy even when dest aliases it.
+      if (!i.src1.is_constant) {
+        e.lsl(i.dest, i.src1, WReg(i.src2.reg().getIdx()));
+      } else {
+        // Read shift amount first — dest may alias src2.
+        e.mov(e.w0, i.src2);
+        if (i.src1.is_constant) {
+          e.mov(i.dest, static_cast<uint64_t>(
+                            static_cast<uint32_t>(i.src1.constant())));
+        } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
+          e.mov(i.dest, i.src1);
+        }
+        e.lsl(i.dest, i.dest, e.w0);
       }
-      e.lsl(i.dest, i.dest, e.w0);
     }
   }
 };
@@ -2093,14 +2293,20 @@ struct SHL_I64 : Sequence<SHL_I64, I<OPCODE_SHL, I64Op, I64Op, I8Op>> {
         e.lsl(i.dest, i.src1, static_cast<uint32_t>(i.src2.constant() & 0x3F));
       }
     } else {
-      // Read shift amount first — dest may alias src2.
-      e.mov(e.x0, XReg(i.src2.reg().getIdx()));
-      if (i.src1.is_constant) {
-        e.mov(i.dest, static_cast<uint64_t>(i.src1.constant()));
-      } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
-        e.mov(i.dest, i.src1);
+      // LSLV/LSRV/ASRV read both sources before writing dest, so a
+      // register amount needs no staging copy even when dest aliases it.
+      if (!i.src1.is_constant) {
+        e.lsl(i.dest, i.src1, XReg(i.src2.reg().getIdx()));
+      } else {
+        // Read shift amount first — dest may alias src2.
+        e.mov(e.x0, XReg(i.src2.reg().getIdx()));
+        if (i.src1.is_constant) {
+          e.mov(i.dest, static_cast<uint64_t>(i.src1.constant()));
+        } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
+          e.mov(i.dest, i.src1);
+        }
+        e.lsl(i.dest, i.dest, e.x0);
       }
-      e.lsl(i.dest, i.dest, e.x0);
     }
   }
 };
@@ -2164,14 +2370,20 @@ struct SHR_I8 : Sequence<SHR_I8, I<OPCODE_SHR, I8Op, I8Op, I8Op>> {
         e.lsr(i.dest, i.src1, static_cast<uint32_t>(i.src2.constant() & 0x1F));
       }
     } else {
-      // Read shift amount first — dest may alias src2.
-      e.mov(e.w0, i.src2);
-      if (i.src1.is_constant) {
-        e.mov(i.dest, static_cast<uint64_t>(i.src1.constant() & 0xFF));
-      } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
-        e.mov(i.dest, i.src1);
+      // LSLV/LSRV/ASRV read both sources before writing dest, so a
+      // register amount needs no staging copy even when dest aliases it.
+      if (!i.src1.is_constant) {
+        e.lsr(i.dest, i.src1, WReg(i.src2.reg().getIdx()));
+      } else {
+        // Read shift amount first — dest may alias src2.
+        e.mov(e.w0, i.src2);
+        if (i.src1.is_constant) {
+          e.mov(i.dest, static_cast<uint64_t>(i.src1.constant() & 0xFF));
+        } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
+          e.mov(i.dest, i.src1);
+        }
+        e.lsr(i.dest, i.dest, e.w0);
       }
-      e.lsr(i.dest, i.dest, e.w0);
     }
   }
 };
@@ -2191,14 +2403,20 @@ struct SHR_I16 : Sequence<SHR_I16, I<OPCODE_SHR, I16Op, I16Op, I8Op>> {
         e.lsr(i.dest, i.src1, static_cast<uint32_t>(i.src2.constant() & 0x1F));
       }
     } else {
-      // Read shift amount first — dest may alias src2.
-      e.mov(e.w0, i.src2);
-      if (i.src1.is_constant) {
-        e.mov(i.dest, static_cast<uint64_t>(i.src1.constant() & 0xFFFF));
-      } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
-        e.mov(i.dest, i.src1);
+      // LSLV/LSRV/ASRV read both sources before writing dest, so a
+      // register amount needs no staging copy even when dest aliases it.
+      if (!i.src1.is_constant) {
+        e.lsr(i.dest, i.src1, WReg(i.src2.reg().getIdx()));
+      } else {
+        // Read shift amount first — dest may alias src2.
+        e.mov(e.w0, i.src2);
+        if (i.src1.is_constant) {
+          e.mov(i.dest, static_cast<uint64_t>(i.src1.constant() & 0xFFFF));
+        } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
+          e.mov(i.dest, i.src1);
+        }
+        e.lsr(i.dest, i.dest, e.w0);
       }
-      e.lsr(i.dest, i.dest, e.w0);
     }
   }
 };
@@ -2213,15 +2431,21 @@ struct SHR_I32 : Sequence<SHR_I32, I<OPCODE_SHR, I32Op, I32Op, I8Op>> {
         e.lsr(i.dest, i.src1, static_cast<uint32_t>(i.src2.constant() & 0x1F));
       }
     } else {
-      // Read shift amount first — dest may alias src2.
-      e.mov(e.w0, i.src2);
-      if (i.src1.is_constant) {
-        e.mov(i.dest,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
-      } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
-        e.mov(i.dest, i.src1);
+      // LSLV/LSRV/ASRV read both sources before writing dest, so a
+      // register amount needs no staging copy even when dest aliases it.
+      if (!i.src1.is_constant) {
+        e.lsr(i.dest, i.src1, WReg(i.src2.reg().getIdx()));
+      } else {
+        // Read shift amount first — dest may alias src2.
+        e.mov(e.w0, i.src2);
+        if (i.src1.is_constant) {
+          e.mov(i.dest, static_cast<uint64_t>(
+                            static_cast<uint32_t>(i.src1.constant())));
+        } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
+          e.mov(i.dest, i.src1);
+        }
+        e.lsr(i.dest, i.dest, e.w0);
       }
-      e.lsr(i.dest, i.dest, e.w0);
     }
   }
 };
@@ -2235,14 +2459,20 @@ struct SHR_I64 : Sequence<SHR_I64, I<OPCODE_SHR, I64Op, I64Op, I8Op>> {
         e.lsr(i.dest, i.src1, static_cast<uint32_t>(i.src2.constant() & 0x3F));
       }
     } else {
-      // Read shift amount first — dest may alias src2.
-      e.mov(e.x0, XReg(i.src2.reg().getIdx()));
-      if (i.src1.is_constant) {
-        e.mov(i.dest, static_cast<uint64_t>(i.src1.constant()));
-      } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
-        e.mov(i.dest, i.src1);
+      // LSLV/LSRV/ASRV read both sources before writing dest, so a
+      // register amount needs no staging copy even when dest aliases it.
+      if (!i.src1.is_constant) {
+        e.lsr(i.dest, i.src1, XReg(i.src2.reg().getIdx()));
+      } else {
+        // Read shift amount first — dest may alias src2.
+        e.mov(e.x0, XReg(i.src2.reg().getIdx()));
+        if (i.src1.is_constant) {
+          e.mov(i.dest, static_cast<uint64_t>(i.src1.constant()));
+        } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
+          e.mov(i.dest, i.src1);
+        }
+        e.lsr(i.dest, i.dest, e.x0);
       }
-      e.lsr(i.dest, i.dest, e.x0);
     }
   }
 };
@@ -2337,15 +2567,21 @@ struct SHA_I32 : Sequence<SHA_I32, I<OPCODE_SHA, I32Op, I32Op, I8Op>> {
         e.asr(i.dest, i.src1, static_cast<uint32_t>(i.src2.constant() & 0x1F));
       }
     } else {
-      // Read shift amount first — dest may alias src2.
-      e.mov(e.w0, i.src2);
-      if (i.src1.is_constant) {
-        e.mov(i.dest,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
-      } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
-        e.mov(i.dest, i.src1);
+      // LSLV/LSRV/ASRV read both sources before writing dest, so a
+      // register amount needs no staging copy even when dest aliases it.
+      if (!i.src1.is_constant) {
+        e.asr(i.dest, i.src1, WReg(i.src2.reg().getIdx()));
+      } else {
+        // Read shift amount first — dest may alias src2.
+        e.mov(e.w0, i.src2);
+        if (i.src1.is_constant) {
+          e.mov(i.dest, static_cast<uint64_t>(
+                            static_cast<uint32_t>(i.src1.constant())));
+        } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
+          e.mov(i.dest, i.src1);
+        }
+        e.asr(i.dest, i.dest, e.w0);
       }
-      e.asr(i.dest, i.dest, e.w0);
     }
   }
 };
@@ -2359,14 +2595,20 @@ struct SHA_I64 : Sequence<SHA_I64, I<OPCODE_SHA, I64Op, I64Op, I8Op>> {
         e.asr(i.dest, i.src1, static_cast<uint32_t>(i.src2.constant() & 0x3F));
       }
     } else {
-      // Read shift amount first — dest may alias src2.
-      e.mov(e.x0, XReg(i.src2.reg().getIdx()));
-      if (i.src1.is_constant) {
-        e.mov(i.dest, static_cast<uint64_t>(i.src1.constant()));
-      } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
-        e.mov(i.dest, i.src1);
+      // LSLV/LSRV/ASRV read both sources before writing dest, so a
+      // register amount needs no staging copy even when dest aliases it.
+      if (!i.src1.is_constant) {
+        e.asr(i.dest, i.src1, XReg(i.src2.reg().getIdx()));
+      } else {
+        // Read shift amount first — dest may alias src2.
+        e.mov(e.x0, XReg(i.src2.reg().getIdx()));
+        if (i.src1.is_constant) {
+          e.mov(i.dest, static_cast<uint64_t>(i.src1.constant()));
+        } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
+          e.mov(i.dest, i.src1);
+        }
+        e.asr(i.dest, i.dest, e.x0);
       }
-      e.asr(i.dest, i.dest, e.x0);
     }
   }
 };
@@ -2448,17 +2690,24 @@ struct ROTATE_LEFT_I32
         }
       }
     } else {
-      // Read shift amount first — dest may alias src2.
-      e.mov(e.w0, i.src2);
-      if (i.src1.is_constant) {
-        e.mov(i.dest,
-              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
-      } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
-        e.mov(i.dest, i.src1);
+      // LSLV/LSRV/ASRV/RORV read both sources before writing dest, so a
+      // register amount needs no staging copy even when dest aliases it.
+      if (!i.src1.is_constant) {
+        e.neg(e.w0, WReg(i.src2.reg().getIdx()));
+        e.ror(i.dest, i.src1, e.w0);
+      } else {
+        // Read shift amount first — dest may alias src2.
+        e.mov(e.w0, i.src2);
+        if (i.src1.is_constant) {
+          e.mov(i.dest, static_cast<uint64_t>(
+                            static_cast<uint32_t>(i.src1.constant())));
+        } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
+          e.mov(i.dest, i.src1);
+        }
+        // ROL(x, n) = ROR(x, -n) since ROR uses amount mod 32
+        e.neg(e.w0, e.w0);
+        e.ror(i.dest, i.dest, e.w0);
       }
-      // ROL(x, n) = ROR(x, -n) since ROR uses amount mod 32
-      e.neg(e.w0, e.w0);
-      e.ror(i.dest, i.dest, e.w0);
     }
   }
 };
@@ -2482,16 +2731,23 @@ struct ROTATE_LEFT_I64
         }
       }
     } else {
-      // Read shift amount first — dest may alias src2.
-      e.mov(e.x0, XReg(i.src2.reg().getIdx()));
-      if (i.src1.is_constant) {
-        e.mov(i.dest, static_cast<uint64_t>(i.src1.constant()));
-      } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
-        e.mov(i.dest, i.src1);
+      // LSLV/LSRV/ASRV/RORV read both sources before writing dest, so a
+      // register amount needs no staging copy even when dest aliases it.
+      if (!i.src1.is_constant) {
+        e.neg(e.x0, XReg(i.src2.reg().getIdx()));
+        e.ror(i.dest, i.src1, e.x0);
+      } else {
+        // Read shift amount first — dest may alias src2.
+        e.mov(e.x0, XReg(i.src2.reg().getIdx()));
+        if (i.src1.is_constant) {
+          e.mov(i.dest, static_cast<uint64_t>(i.src1.constant()));
+        } else if (i.dest.reg().getIdx() != i.src1.reg().getIdx()) {
+          e.mov(i.dest, i.src1);
+        }
+        // ROL(x, n) = ROR(x, -n) since ROR uses amount mod 64
+        e.neg(e.x0, e.x0);
+        e.ror(i.dest, i.dest, e.x0);
       }
-      // ROL(x, n) = ROR(x, -n) since ROR uses amount mod 64
-      e.neg(e.x0, e.x0);
-      e.ror(i.dest, i.dest, e.x0);
     }
   }
 };
@@ -2659,6 +2915,16 @@ EMITTER_OPCODE_TABLE(OPCODE_CNTLZ, CNTLZ_I8, CNTLZ_I16, CNTLZ_I32, CNTLZ_I64);
   struct NAME##_I32                                                            \
       : Sequence<NAME##_I32, I<OPCODE_##NAME, I8Op, I32Op, I32Op>> {           \
     static void Emit(A64Emitter& e, const EmitArgType& i) {                    \
+      /* If the previous sequence was an ANDS of this register, Z already   */ \
+      /* answers a compare against zero for EQ/NE (ANDS clears C and V).    */ \
+      if ((Xbyak_aarch64::COND == Xbyak_aarch64::EQ ||                         \
+           Xbyak_aarch64::COND == Xbyak_aarch64::NE) &&                        \
+          !i.src1.is_constant && i.src2.is_constant &&                         \
+          i.src2.constant() == 0 &&                                            \
+          e.FlagsHoldZeroTest(i.src1.reg().getIdx(), false)) {                 \
+        e.cset(i.dest, Xbyak_aarch64::COND);                                   \
+        return;                                                                \
+      }                                                                        \
       if (i.src1.is_constant) {                                                \
         e.mov(e.w0, static_cast<uint64_t>(                                     \
                         static_cast<uint32_t>(i.src1.constant())));            \
@@ -2680,6 +2946,14 @@ EMITTER_OPCODE_TABLE(OPCODE_CNTLZ, CNTLZ_I8, CNTLZ_I16, CNTLZ_I32, CNTLZ_I64);
   struct NAME##_I64                                                            \
       : Sequence<NAME##_I64, I<OPCODE_##NAME, I8Op, I64Op, I64Op>> {           \
     static void Emit(A64Emitter& e, const EmitArgType& i) {                    \
+      if ((Xbyak_aarch64::COND == Xbyak_aarch64::EQ ||                         \
+           Xbyak_aarch64::COND == Xbyak_aarch64::NE) &&                        \
+          !i.src1.is_constant && i.src2.is_constant &&                         \
+          i.src2.constant() == 0 &&                                            \
+          e.FlagsHoldZeroTest(i.src1.reg().getIdx(), true)) {                  \
+        e.cset(i.dest, Xbyak_aarch64::COND);                                   \
+        return;                                                                \
+      }                                                                        \
       if (i.src1.is_constant) {                                                \
         e.mov(e.x0, static_cast<uint64_t>(i.src1.constant()));                 \
         if (i.src2.is_constant) {                                              \
@@ -2810,7 +3084,15 @@ struct SELECT_I8
     if (i.src1.is_constant) {
       e.mov(e.w0, static_cast<uint64_t>(i.src1.constant() & 0xFF));
     }
-    e.cmp(cond, 0);
+    // An adjacent producer may have left a condition equivalent to the
+    // nonzero test in NZCV (ANDS -> NE); the select picks on that condition
+    // directly. The constant loads below leave NZCV alone.
+    Xbyak_aarch64::Cond sel_cond = Xbyak_aarch64::NE;
+    if (i.src1.is_constant ||
+        !e.FlagsNonzeroCondHeld(i.src1.reg().getIdx(), false, &sel_cond)) {
+      e.cmp(cond, 0);
+      sel_cond = Xbyak_aarch64::NE;
+    }
     if (i.src2.is_constant) {
       e.mov(e.w1, static_cast<uint64_t>(i.src2.constant() & 0xFF));
     }
@@ -2819,7 +3101,7 @@ struct SELECT_I8
     }
     WReg s2 = i.src2.is_constant ? e.w1 : WReg(i.src2.reg().getIdx());
     WReg s3 = i.src3.is_constant ? e.w2 : WReg(i.src3.reg().getIdx());
-    e.csel(i.dest, s2, s3, Xbyak_aarch64::NE);
+    e.csel(i.dest, s2, s3, sel_cond);
   }
 };
 struct SELECT_I16
@@ -2829,7 +3111,15 @@ struct SELECT_I16
     if (i.src1.is_constant) {
       e.mov(e.w0, static_cast<uint64_t>(i.src1.constant() & 0xFF));
     }
-    e.cmp(cond, 0);
+    // An adjacent producer may have left a condition equivalent to the
+    // nonzero test in NZCV (ANDS -> NE); the select picks on that condition
+    // directly. The constant loads below leave NZCV alone.
+    Xbyak_aarch64::Cond sel_cond = Xbyak_aarch64::NE;
+    if (i.src1.is_constant ||
+        !e.FlagsNonzeroCondHeld(i.src1.reg().getIdx(), false, &sel_cond)) {
+      e.cmp(cond, 0);
+      sel_cond = Xbyak_aarch64::NE;
+    }
     if (i.src2.is_constant) {
       e.mov(e.w1, static_cast<uint64_t>(i.src2.constant() & 0xFFFF));
     }
@@ -2838,7 +3128,7 @@ struct SELECT_I16
     }
     WReg s2 = i.src2.is_constant ? e.w1 : WReg(i.src2.reg().getIdx());
     WReg s3 = i.src3.is_constant ? e.w2 : WReg(i.src3.reg().getIdx());
-    e.csel(i.dest, s2, s3, Xbyak_aarch64::NE);
+    e.csel(i.dest, s2, s3, sel_cond);
   }
 };
 struct SELECT_I32
@@ -2848,7 +3138,15 @@ struct SELECT_I32
     if (i.src1.is_constant) {
       e.mov(e.w0, static_cast<uint64_t>(i.src1.constant() & 0xFF));
     }
-    e.cmp(cond, 0);
+    // An adjacent producer may have left a condition equivalent to the
+    // nonzero test in NZCV (ANDS -> NE); the select picks on that condition
+    // directly. The constant loads below leave NZCV alone.
+    Xbyak_aarch64::Cond sel_cond = Xbyak_aarch64::NE;
+    if (i.src1.is_constant ||
+        !e.FlagsNonzeroCondHeld(i.src1.reg().getIdx(), false, &sel_cond)) {
+      e.cmp(cond, 0);
+      sel_cond = Xbyak_aarch64::NE;
+    }
     if (i.src2.is_constant) {
       e.mov(e.w1,
             static_cast<uint64_t>(static_cast<uint32_t>(i.src2.constant())));
@@ -2859,7 +3157,7 @@ struct SELECT_I32
     }
     WReg s2 = i.src2.is_constant ? e.w1 : WReg(i.src2.reg().getIdx());
     WReg s3 = i.src3.is_constant ? e.w2 : WReg(i.src3.reg().getIdx());
-    e.csel(i.dest, s2, s3, Xbyak_aarch64::NE);
+    e.csel(i.dest, s2, s3, sel_cond);
   }
 };
 struct SELECT_I64
@@ -2869,7 +3167,15 @@ struct SELECT_I64
     if (i.src1.is_constant) {
       e.mov(e.w0, static_cast<uint64_t>(i.src1.constant() & 0xFF));
     }
-    e.cmp(cond, 0);
+    // An adjacent producer may have left a condition equivalent to the
+    // nonzero test in NZCV (ANDS -> NE); the select picks on that condition
+    // directly. The constant loads below leave NZCV alone.
+    Xbyak_aarch64::Cond sel_cond = Xbyak_aarch64::NE;
+    if (i.src1.is_constant ||
+        !e.FlagsNonzeroCondHeld(i.src1.reg().getIdx(), false, &sel_cond)) {
+      e.cmp(cond, 0);
+      sel_cond = Xbyak_aarch64::NE;
+    }
     if (i.src2.is_constant) {
       e.mov(e.x1, static_cast<uint64_t>(i.src2.constant()));
     }
@@ -2878,7 +3184,7 @@ struct SELECT_I64
     }
     XReg s2 = i.src2.is_constant ? e.x1 : XReg(i.src2.reg().getIdx());
     XReg s3 = i.src3.is_constant ? e.x2 : XReg(i.src3.reg().getIdx());
-    e.csel(i.dest, s2, s3, Xbyak_aarch64::NE);
+    e.csel(i.dest, s2, s3, sel_cond);
   }
 };
 struct SELECT_F32
@@ -2888,7 +3194,15 @@ struct SELECT_F32
     if (i.src1.is_constant) {
       e.mov(e.w0, static_cast<uint64_t>(i.src1.constant() & 0xFF));
     }
-    e.cmp(cond, 0);
+    // An adjacent producer may have left a condition equivalent to the
+    // nonzero test in NZCV (ANDS -> NE); the select picks on that condition
+    // directly. The constant loads below leave NZCV alone.
+    Xbyak_aarch64::Cond sel_cond = Xbyak_aarch64::NE;
+    if (i.src1.is_constant ||
+        !e.FlagsNonzeroCondHeld(i.src1.reg().getIdx(), false, &sel_cond)) {
+      e.cmp(cond, 0);
+      sel_cond = Xbyak_aarch64::NE;
+    }
     if (i.src2.is_constant) {
       union {
         float f;
@@ -2909,7 +3223,7 @@ struct SELECT_F32
     }
     SReg s2 = i.src2.is_constant ? e.s0 : SReg(i.src2.reg().getIdx());
     SReg s3 = i.src3.is_constant ? e.s1 : SReg(i.src3.reg().getIdx());
-    e.fcsel(i.dest, s2, s3, Xbyak_aarch64::NE);
+    e.fcsel(i.dest, s2, s3, sel_cond);
   }
 };
 struct SELECT_F64
@@ -2919,7 +3233,15 @@ struct SELECT_F64
     if (i.src1.is_constant) {
       e.mov(e.w0, static_cast<uint64_t>(i.src1.constant() & 0xFF));
     }
-    e.cmp(cond, 0);
+    // An adjacent producer may have left a condition equivalent to the
+    // nonzero test in NZCV (ANDS -> NE); the select picks on that condition
+    // directly. The constant loads below leave NZCV alone.
+    Xbyak_aarch64::Cond sel_cond = Xbyak_aarch64::NE;
+    if (i.src1.is_constant ||
+        !e.FlagsNonzeroCondHeld(i.src1.reg().getIdx(), false, &sel_cond)) {
+      e.cmp(cond, 0);
+      sel_cond = Xbyak_aarch64::NE;
+    }
     if (i.src2.is_constant) {
       union {
         double d;
@@ -2940,7 +3262,7 @@ struct SELECT_F64
     }
     DReg s2 = i.src2.is_constant ? e.d0 : DReg(i.src2.reg().getIdx());
     DReg s3 = i.src3.is_constant ? e.d1 : DReg(i.src3.reg().getIdx());
-    e.fcsel(i.dest, s2, s3, Xbyak_aarch64::NE);
+    e.fcsel(i.dest, s2, s3, sel_cond);
   }
 };
 struct SELECT_V128_V128
@@ -2959,20 +3281,13 @@ struct SELECT_V128_V128
       // dest already holds the mask. BSL is safe here.
       e.bsl(VReg(d).b16, VReg(s3).b16, VReg(s2).b16);
     } else if (d == s3) {
-      // dest holds the mask=1 value. BIT inserts mask=1 bits from s3, keeps
-      // dest (=s2-candidate) where mask=0... no, dest=s3 not s2.
-      // Use: copy s2 to scratch, then BIT(scratch, s3, mask), move to dest.
-      // Or: copy mask to scratch v0, copy s2 to dest, BIT(dest, s3_orig, v0).
-      // Simplest: use scratch v0 for mask, then BSL.
-      e.orr(VReg(0).b16, VReg(s1).b16, VReg(s1).b16);  // v0 = mask
-      e.bsl(VReg(0).b16, VReg(s3).b16, VReg(s2).b16);  // v0 = result
-      e.orr(VReg(d).b16, VReg(0).b16, VReg(0).b16);    // dest = result
+      // dest already holds the mask=1 value: keep it where the mask is set
+      // and take s2 elsewhere, which is BIF exactly.
+      e.bif(VReg(d).b16, VReg(s2).b16, VReg(s1).b16);
     } else if (d == s2) {
-      // dest holds the mask=0 value. BIF inserts ~mask bits from s2,
-      // but dest=s2... Use scratch for mask.
-      e.orr(VReg(0).b16, VReg(s1).b16, VReg(s1).b16);  // v0 = mask
-      e.bsl(VReg(0).b16, VReg(s3).b16, VReg(s2).b16);  // v0 = result
-      e.orr(VReg(d).b16, VReg(0).b16, VReg(0).b16);    // dest = result
+      // dest already holds the mask=0 value: insert s3 where the mask is set
+      // and keep dest elsewhere, which is BIT exactly.
+      e.bit(VReg(d).b16, VReg(s3).b16, VReg(s1).b16);
     } else {
       // No aliasing — copy mask to dest, then BSL.
       e.orr(VReg(d).b16, VReg(s1).b16, VReg(s1).b16);
@@ -3274,6 +3589,10 @@ EMITTER_OPCODE_TABLE(OPCODE_DID_SATURATE, DID_SATURATE);
 // ============================================================================
 struct MAX_F32 : Sequence<MAX_F32, I<OPCODE_MAX, F32Op, F32Op, F32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         float f;
@@ -3282,7 +3601,16 @@ struct MAX_F32 : Sequence<MAX_F32, I<OPCODE_MAX, F32Op, F32Op, F32Op>> {
       c.f = i.src1.constant();
       e.mov(e.w0, static_cast<uint64_t>(c.u));
       e.fmov(e.s0, e.w0);
-      e.fmax(i.dest, e.s0, i.src2.is_constant ? e.s1 : i.src2);
+      if (i.src2.is_constant) {
+        // Both constant: the second one has to be materialised too, or the
+        // fmax reads whatever the previous sequence left in s1.
+        c.f = i.src2.constant();
+        e.mov(e.w0, static_cast<uint64_t>(c.u));
+        e.fmov(e.s1, e.w0);
+        e.fmax(i.dest, e.s0, e.s1);
+      } else {
+        e.fmax(i.dest, e.s0, i.src2);
+      }
     } else if (i.src2.is_constant) {
       union {
         float f;
@@ -3299,6 +3627,10 @@ struct MAX_F32 : Sequence<MAX_F32, I<OPCODE_MAX, F32Op, F32Op, F32Op>> {
 };
 struct MAX_F64 : Sequence<MAX_F64, I<OPCODE_MAX, F64Op, F64Op, F64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         double d;
@@ -3307,7 +3639,14 @@ struct MAX_F64 : Sequence<MAX_F64, I<OPCODE_MAX, F64Op, F64Op, F64Op>> {
       c.d = i.src1.constant();
       e.mov(e.x0, c.u);
       e.fmov(e.d0, e.x0);
-      e.fmax(i.dest, e.d0, i.src2.is_constant ? e.d1 : i.src2);
+      if (i.src2.is_constant) {
+        c.d = i.src2.constant();
+        e.mov(e.x0, c.u);
+        e.fmov(e.d1, e.x0);
+        e.fmax(i.dest, e.d0, e.d1);
+      } else {
+        e.fmax(i.dest, e.d0, i.src2);
+      }
     } else if (i.src2.is_constant) {
       union {
         double d;
@@ -3419,6 +3758,10 @@ struct MIN_I64 : Sequence<MIN_I64, I<OPCODE_MIN, I64Op, I64Op, I64Op>> {
 };
 struct MIN_F32 : Sequence<MIN_F32, I<OPCODE_MIN, F32Op, F32Op, F32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         float f;
@@ -3427,7 +3770,14 @@ struct MIN_F32 : Sequence<MIN_F32, I<OPCODE_MIN, F32Op, F32Op, F32Op>> {
       c.f = i.src1.constant();
       e.mov(e.w0, static_cast<uint64_t>(c.u));
       e.fmov(e.s0, e.w0);
-      e.fmin(i.dest, e.s0, i.src2.is_constant ? e.s1 : i.src2);
+      if (i.src2.is_constant) {
+        c.f = i.src2.constant();
+        e.mov(e.w0, static_cast<uint64_t>(c.u));
+        e.fmov(e.s1, e.w0);
+        e.fmin(i.dest, e.s0, e.s1);
+      } else {
+        e.fmin(i.dest, e.s0, i.src2);
+      }
     } else if (i.src2.is_constant) {
       union {
         float f;
@@ -3444,6 +3794,10 @@ struct MIN_F32 : Sequence<MIN_F32, I<OPCODE_MIN, F32Op, F32Op, F32Op>> {
 };
 struct MIN_F64 : Sequence<MIN_F64, I<OPCODE_MIN, F64Op, F64Op, F64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         double d;
@@ -3452,7 +3806,14 @@ struct MIN_F64 : Sequence<MIN_F64, I<OPCODE_MIN, F64Op, F64Op, F64Op>> {
       c.d = i.src1.constant();
       e.mov(e.x0, c.u);
       e.fmov(e.d0, e.x0);
-      e.fmin(i.dest, e.d0, i.src2.is_constant ? e.d1 : i.src2);
+      if (i.src2.is_constant) {
+        c.d = i.src2.constant();
+        e.mov(e.x0, c.u);
+        e.fmov(e.d1, e.x0);
+        e.fmin(i.dest, e.d0, e.d1);
+      } else {
+        e.fmin(i.dest, e.d0, i.src2);
+      }
     } else if (i.src2.is_constant) {
       union {
         double d;
@@ -3491,6 +3852,10 @@ EMITTER_OPCODE_TABLE(OPCODE_MIN, MIN_I8, MIN_I16, MIN_I32, MIN_I64, MIN_F32,
 struct CONVERT_I32_F32
     : Sequence<CONVERT_I32_F32, I<OPCODE_CONVERT, I32Op, F32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         float f;
@@ -3512,6 +3877,10 @@ struct CONVERT_I32_F32
 struct CONVERT_I32_F64
     : Sequence<CONVERT_I32_F64, I<OPCODE_CONVERT, I32Op, F64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         double d;
@@ -3534,6 +3903,10 @@ struct CONVERT_I32_F64
 struct CONVERT_I64_F64
     : Sequence<CONVERT_I64_F64, I<OPCODE_CONVERT, I64Op, F64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         double d;
@@ -3555,6 +3928,10 @@ struct CONVERT_I64_F64
 struct CONVERT_F32_I32
     : Sequence<CONVERT_F32_I32, I<OPCODE_CONVERT, F32Op, I32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       e.mov(e.w0,
             static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
@@ -3567,6 +3944,10 @@ struct CONVERT_F32_I32
 struct CONVERT_F64_I64
     : Sequence<CONVERT_F64_I64, I<OPCODE_CONVERT, F64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       e.mov(e.x0, static_cast<uint64_t>(i.src1.constant()));
       e.scvtf(i.dest, e.x0);
@@ -3620,6 +4001,10 @@ EMITTER_OPCODE_TABLE(OPCODE_CONVERT, CONVERT_I32_F32, CONVERT_I32_F64,
 // ============================================================================
 struct ROUND_F32 : Sequence<ROUND_F32, I<OPCODE_ROUND, F32Op, F32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     // Round mode is in i.instr->flags.
     if (i.src1.is_constant) {
       union {
@@ -3653,6 +4038,10 @@ struct ROUND_F32 : Sequence<ROUND_F32, I<OPCODE_ROUND, F32Op, F32Op>> {
 };
 struct ROUND_F64 : Sequence<ROUND_F64, I<OPCODE_ROUND, F64Op, F64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         double d;
@@ -3789,6 +4178,10 @@ EMITTER_OPCODE_TABLE(OPCODE_SQRT, SQRT_F32, SQRT_F64, SQRT_V128);
 // ============================================================================
 struct IS_NAN_F32 : Sequence<IS_NAN_F32, I<OPCODE_IS_NAN, I8Op, F32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         float f;
@@ -3807,6 +4200,10 @@ struct IS_NAN_F32 : Sequence<IS_NAN_F32, I<OPCODE_IS_NAN, I8Op, F32Op>> {
 };
 struct IS_NAN_F64 : Sequence<IS_NAN_F64, I<OPCODE_IS_NAN, I8Op, F64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         double d;
@@ -3830,6 +4227,10 @@ EMITTER_OPCODE_TABLE(OPCODE_IS_NAN, IS_NAN_F32, IS_NAN_F64);
 struct COMPARE_EQ_F32
     : Sequence<COMPARE_EQ_F32, I<OPCODE_COMPARE_EQ, I8Op, F32Op, F32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         float f;
@@ -3868,6 +4269,10 @@ struct COMPARE_EQ_F32
 struct COMPARE_EQ_F64
     : Sequence<COMPARE_EQ_F64, I<OPCODE_COMPARE_EQ, I8Op, F64Op, F64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         double d;
@@ -3907,6 +4312,10 @@ struct COMPARE_EQ_F64
 struct COMPARE_NE_F32
     : Sequence<COMPARE_NE_F32, I<OPCODE_COMPARE_NE, I8Op, F32Op, F32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         float f;
@@ -3945,6 +4354,10 @@ struct COMPARE_NE_F32
 struct COMPARE_NE_F64
     : Sequence<COMPARE_NE_F64, I<OPCODE_COMPARE_NE, I8Op, F64Op, F64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     if (i.src1.is_constant) {
       union {
         double d;
@@ -3982,82 +4395,88 @@ struct COMPARE_NE_F64
 };
 
 // Float compares for SLT/SLE/SGT/SGE (use MI/LS/GT/GE for ordered compares)
-#define DEFINE_FLOAT_COMPARE(NAME, COND_S, COND_D)                   \
-  struct NAME##_F32                                                  \
-      : Sequence<NAME##_F32, I<OPCODE_##NAME, I8Op, F32Op, F32Op>> { \
-    static void Emit(A64Emitter& e, const EmitArgType& i) {          \
-      if (i.src1.is_constant) {                                      \
-        union {                                                      \
-          float f;                                                   \
-          uint32_t u;                                                \
-        } c;                                                         \
-        c.f = i.src1.constant();                                     \
-        e.mov(e.w0, static_cast<uint64_t>(c.u));                     \
-        e.fmov(e.s0, e.w0);                                          \
-        if (i.src2.is_constant) {                                    \
-          union {                                                    \
-            float f;                                                 \
-            uint32_t u;                                              \
-          } c2;                                                      \
-          c2.f = i.src2.constant();                                  \
-          e.mov(e.w0, static_cast<uint64_t>(c2.u));                  \
-          e.fmov(e.s1, e.w0);                                        \
-          e.fcmp(e.s0, e.s1);                                        \
-        } else {                                                     \
-          e.fcmp(e.s0, i.src2);                                      \
-        }                                                            \
-      } else if (i.src2.is_constant) {                               \
-        union {                                                      \
-          float f;                                                   \
-          uint32_t u;                                                \
-        } c;                                                         \
-        c.f = i.src2.constant();                                     \
-        e.mov(e.w0, static_cast<uint64_t>(c.u));                     \
-        e.fmov(e.s0, e.w0);                                          \
-        e.fcmp(i.src1, e.s0);                                        \
-      } else {                                                       \
-        e.fcmp(i.src1, i.src2);                                      \
-      }                                                              \
-      e.cset(i.dest, Xbyak_aarch64::COND_S);                         \
-    }                                                                \
-  };                                                                 \
-  struct NAME##_F64                                                  \
-      : Sequence<NAME##_F64, I<OPCODE_##NAME, I8Op, F64Op, F64Op>> { \
-    static void Emit(A64Emitter& e, const EmitArgType& i) {          \
-      if (i.src1.is_constant) {                                      \
-        union {                                                      \
-          double d;                                                  \
-          uint64_t u;                                                \
-        } c;                                                         \
-        c.d = i.src1.constant();                                     \
-        e.mov(e.x0, c.u);                                            \
-        e.fmov(e.d0, e.x0);                                          \
-        if (i.src2.is_constant) {                                    \
-          union {                                                    \
-            double d;                                                \
-            uint64_t u;                                              \
-          } c2;                                                      \
-          c2.d = i.src2.constant();                                  \
-          e.mov(e.x0, c2.u);                                         \
-          e.fmov(e.d1, e.x0);                                        \
-          e.fcmp(e.d0, e.d1);                                        \
-        } else {                                                     \
-          e.fcmp(e.d0, i.src2);                                      \
-        }                                                            \
-      } else if (i.src2.is_constant) {                               \
-        union {                                                      \
-          double d;                                                  \
-          uint64_t u;                                                \
-        } c;                                                         \
-        c.d = i.src2.constant();                                     \
-        e.mov(e.x0, c.u);                                            \
-        e.fmov(e.d0, e.x0);                                          \
-        e.fcmp(i.src1, e.d0);                                        \
-      } else {                                                       \
-        e.fcmp(i.src1, i.src2);                                      \
-      }                                                              \
-      e.cset(i.dest, Xbyak_aarch64::COND_D);                         \
-    }                                                                \
+#define DEFINE_FLOAT_COMPARE(NAME, COND_S, COND_D)                     \
+  struct NAME##_F32                                                    \
+      : Sequence<NAME##_F32, I<OPCODE_##NAME, I8Op, F32Op, F32Op>> {   \
+    static void Emit(A64Emitter& e, const EmitArgType& i) {            \
+      /* fcmp reads FPCR, and the last vector float op in the block */ \
+      /* left it in VMX mode. Free when the mode already matches.   */ \
+      e.ChangeFpcrMode(FPCRMode::Fpu);                                 \
+      if (i.src1.is_constant) {                                        \
+        union {                                                        \
+          float f;                                                     \
+          uint32_t u;                                                  \
+        } c;                                                           \
+        c.f = i.src1.constant();                                       \
+        e.mov(e.w0, static_cast<uint64_t>(c.u));                       \
+        e.fmov(e.s0, e.w0);                                            \
+        if (i.src2.is_constant) {                                      \
+          union {                                                      \
+            float f;                                                   \
+            uint32_t u;                                                \
+          } c2;                                                        \
+          c2.f = i.src2.constant();                                    \
+          e.mov(e.w0, static_cast<uint64_t>(c2.u));                    \
+          e.fmov(e.s1, e.w0);                                          \
+          e.fcmp(e.s0, e.s1);                                          \
+        } else {                                                       \
+          e.fcmp(e.s0, i.src2);                                        \
+        }                                                              \
+      } else if (i.src2.is_constant) {                                 \
+        union {                                                        \
+          float f;                                                     \
+          uint32_t u;                                                  \
+        } c;                                                           \
+        c.f = i.src2.constant();                                       \
+        e.mov(e.w0, static_cast<uint64_t>(c.u));                       \
+        e.fmov(e.s0, e.w0);                                            \
+        e.fcmp(i.src1, e.s0);                                          \
+      } else {                                                         \
+        e.fcmp(i.src1, i.src2);                                        \
+      }                                                                \
+      e.cset(i.dest, Xbyak_aarch64::COND_S);                           \
+    }                                                                  \
+  };                                                                   \
+  struct NAME##_F64                                                    \
+      : Sequence<NAME##_F64, I<OPCODE_##NAME, I8Op, F64Op, F64Op>> {   \
+    static void Emit(A64Emitter& e, const EmitArgType& i) {            \
+      /* fcmp reads FPCR, and the last vector float op in the block */ \
+      /* left it in VMX mode. Free when the mode already matches.   */ \
+      e.ChangeFpcrMode(FPCRMode::Fpu);                                 \
+      if (i.src1.is_constant) {                                        \
+        union {                                                        \
+          double d;                                                    \
+          uint64_t u;                                                  \
+        } c;                                                           \
+        c.d = i.src1.constant();                                       \
+        e.mov(e.x0, c.u);                                              \
+        e.fmov(e.d0, e.x0);                                            \
+        if (i.src2.is_constant) {                                      \
+          union {                                                      \
+            double d;                                                  \
+            uint64_t u;                                                \
+          } c2;                                                        \
+          c2.d = i.src2.constant();                                    \
+          e.mov(e.x0, c2.u);                                           \
+          e.fmov(e.d1, e.x0);                                          \
+          e.fcmp(e.d0, e.d1);                                          \
+        } else {                                                       \
+          e.fcmp(e.d0, i.src2);                                        \
+        }                                                              \
+      } else if (i.src2.is_constant) {                                 \
+        union {                                                        \
+          double d;                                                    \
+          uint64_t u;                                                  \
+        } c;                                                           \
+        c.d = i.src2.constant();                                       \
+        e.mov(e.x0, c.u);                                              \
+        e.fmov(e.d0, e.x0);                                            \
+        e.fcmp(i.src1, e.d0);                                          \
+      } else {                                                         \
+        e.fcmp(i.src1, i.src2);                                        \
+      }                                                                \
+      e.cset(i.dest, Xbyak_aarch64::COND_D);                           \
+    }                                                                  \
   }
 
 DEFINE_FLOAT_COMPARE(COMPARE_SLT, MI, MI);
@@ -4184,6 +4603,30 @@ struct MUL_ADD_F64
                           i.instr->flags & ARITHMETIC_NEGATE_RESULT);
   }
 };
+// Register plan for the V128 FMA sequences. `tmp` is live scratch across the
+// NaN fixup while the sources still matter: the dest register serves unless it
+// aliases a source (vmaddfp v3,v1,v2,v3), in which case a free scratch-bank
+// register does - one always exists, because an all-constant operand set
+// occupies the whole bank but then no source is allocated and dest cannot
+// alias. `qs` is written only after the sources are dead, so the first
+// scratch-bank register that is not tmp serves.
+static void PickFmaFixupScratch(int a, int c, int b, int d, int* out_tmp,
+                                int* out_qs) {
+  auto in_sources = [&](int r) { return r == a || r == c || r == b; };
+  int tmp;
+  if (!in_sources(d)) {
+    tmp = d;
+  } else if (!in_sources(0)) {
+    tmp = 0;
+  } else if (!in_sources(1)) {
+    tmp = 1;
+  } else {
+    tmp = 3;
+  }
+  *out_tmp = tmp;
+  *out_qs = tmp != 0 ? 0 : 1;
+}
+
 struct MUL_ADD_V128
     : Sequence<MUL_ADD_V128,
                I<OPCODE_MUL_ADD, V128Op, V128Op, V128Op, V128Op>> {
@@ -4192,19 +4635,25 @@ struct MUL_ADD_V128
     EmitWithVmxDenormalFlushFpcr(e, [&] {
       const int d = i.dest.reg().getIdx();
 
-      // dest is free until the result is stored, so it lends the fixup the
-      // scratch register v0-v3 cannot cover.
-      PrepareVmxFmaSources(e, i.src1, i.src2, i.src3, d);
+      // On software-flush hosts the sources are copied to v0/v1/v3 and dest
+      // lends the fixup its scratch; on FZ hosts allocated sources feed the
+      // FMA directly and the scratch plan below avoids them.
+      int a, c, b;
+      PrepareVmxFmaSources(e, i.src1, i.src2, i.src3, d, &a, &c, &b);
+      int tmp, qs;
+      PickFmaFixupScratch(a, c, b, d, &tmp, &qs);
 
-      e.mov(VReg(2).b16, VReg(3).b16);
-      e.fmla(VReg(2).s4, VReg(0).s4, VReg(1).s4);
+      e.mov(VReg(2).b16, VReg(b).b16);
+      e.fmla(VReg(2).s4, VReg(a).s4, VReg(c).s4);
 
       if (i.instr->flags & ARITHMETIC_NEGATE_RESULT) {
         e.fneg(VReg(2).s4, VReg(2).s4);
       }
-      FixupVmxNan_V128_Fma(e, d);
+      FixupVmxNan_V128_Fma(e, a, c, b, tmp, qs);
 
-      // Flush output denormals.
+      // Flush output denormals (NJ-gated). With accurate_vmx_denormal_flush
+      // the input flush is pinned on while this one stays NJ-gated; harmless,
+      // since the VmxDaz FPCR flushes outputs in hardware.
       if (!e.IsFeatureEnabled(xe::arm64::kA64FZFlushesInputs)) {
         FlushDenormals_V128(e, 2, 0, 1);
       }
@@ -4261,26 +4710,33 @@ struct MUL_SUB_V128
                I<OPCODE_MUL_SUB, V128Op, V128Op, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
     // dest = s1*s2 - s3 with VMX denormal flushing and PPC NaN propagation.
-    // Same as MUL_ADD but negate s3 before the fmla. v3 keeps the un-negated
-    // s3, which is the operand the fixup propagates.
+    // Same as MUL_ADD but negate s3 before the fmla. The source register
+    // keeps the un-negated s3, which is the operand the fixup propagates.
     EmitWithVmxDenormalFlushFpcr(e, [&] {
       const int d = i.dest.reg().getIdx();
 
-      PrepareVmxFmaSources(e, i.src1, i.src2, i.src3, d);
+      int a, c, b;
+      PrepareVmxFmaSources(e, i.src1, i.src2, i.src3, d, &a, &c, &b);
+      int tmp, qs;
+      PickFmaFixupScratch(a, c, b, d, &tmp, &qs);
 
-      e.mov(VReg(2).b16, VReg(3).b16);
+      e.mov(VReg(2).b16, VReg(b).b16);
       e.fneg(VReg(2).s4, VReg(2).s4);
-      e.fmla(VReg(2).s4, VReg(0).s4, VReg(1).s4);
+      e.fmla(VReg(2).s4, VReg(a).s4, VReg(c).s4);
 
-      // Negate before the fixup, never after: the fixup overwrites every NaN
-      // lane, and hardware leaves a NaN result's sign alone.
+      // Negate before the fixup, never after: the fixup inserts operand NaNs
+      // over the negated result, and hardware leaves a NaN result's sign
+      // alone. A NaN generated by the multiply itself (0*inf) is not an
+      // operand NaN and keeps the sign the negation gave it.
       if (i.instr->flags & ARITHMETIC_NEGATE_RESULT) {
         e.fneg(VReg(2).s4, VReg(2).s4);
       }
 
-      FixupVmxNan_V128_Fma(e, d);
+      FixupVmxNan_V128_Fma(e, a, c, b, tmp, qs);
 
-      // Flush output denormals.
+      // Flush output denormals (NJ-gated). With accurate_vmx_denormal_flush
+      // the input flush is pinned on while this one stays NJ-gated; harmless,
+      // since the VmxDaz FPCR flushes outputs in hardware.
       if (!e.IsFeatureEnabled(xe::arm64::kA64FZFlushesInputs)) {
         FlushDenormals_V128(e, 2, 0, 1);
       }
@@ -4625,6 +5081,10 @@ struct RSQRT_F32 : Sequence<RSQRT_F32, I<OPCODE_RSQRT, F32Op, F32Op>> {
 };
 struct RSQRT_F64 : Sequence<RSQRT_F64, I<OPCODE_RSQRT, F64Op, F64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    // FPCR is left in VMX mode by the last vector float op in the block, and
+    // this sequence's result depends on it (flush-to-zero, rounding, NaN
+    // default). The call is free when the mode already matches.
+    e.ChangeFpcrMode(FPCRMode::Fpu);
     // PPC frsqrte uses a specific lookup table, not a high-precision estimate.
     DReg src = i.src1.is_constant ? e.d0 : DReg(i.src1.reg().getIdx());
     if (i.src1.is_constant) {

--- a/src/xenia/cpu/backend/a64/a64_stack_layout.h
+++ b/src/xenia/cpu/backend/a64/a64_stack_layout.h
@@ -44,26 +44,37 @@ class StackLayout {
    *  +------------------+
    *  | scratch, 48b     | sp + 0x000  (3 x Q for VMX FP scratch)
    *  | guest ret addr   | sp + 0x030  (guest PPC return address)
-   *  | call ret addr    | sp + 0x038  (next call's guest PPC return addr)
-   *  | host ret addr    | sp + 0x040  (host x30/LR, for ret instruction)
-   *  | reserved         | sp + 0x048
-   *  |  ... locals ...  |
+   *  | host ret addr    | sp + 0x038  (host x30/LR, for ret instruction)
+   *  | call ret addr    | sp + 0x040  (next call's guest PPC return addr)
+   *  | stackpoint prev  | sp + 0x048  (A64StackpointNode::prev_)
+   *  | guest r1, lr     | sp + 0x050  (A64StackpointNode guest words)
+   *  | padding          | sp + 0x058
+   *  |  ... locals ...  | sp + 0x060
    *  +------------------+
    *
-   * Minimum size: 80 bytes (aligned to 16).
+   * Minimum size: 96 bytes (aligned to 16).
    *
    * Convention: at guest function entry, x0 holds the guest PPC return
    * address. The prolog stores it to GUEST_RET_ADDR and saves x30 (host
    * LR) to HOST_RET_ADDR.
    */
-  static constexpr size_t GUEST_STACK_SIZE = 80;  // 16-byte aligned
+  static constexpr size_t GUEST_STACK_SIZE = 96;  // 16-byte aligned
   static constexpr size_t GUEST_SCRATCH = 0;      // 48 bytes (3 x Q)
+  // GUEST_RET_ADDR and HOST_RET_ADDR are adjacent on purpose: the prolog
+  // saves both with one stp and the call-return teardown reloads both with
+  // one ldp.
   static constexpr size_t GUEST_RET_ADDR = 48;
-  static constexpr size_t GUEST_CALL_RET_ADDR = 56;
-  static constexpr size_t HOST_RET_ADDR = 64;
-  // Reserved padding. Longjmp detection state lives in A64BackendContext so it
-  // can be checked even when native SP still points at a skipped frame.
-  static constexpr size_t GUEST_RESERVED = 72;
+  static constexpr size_t HOST_RET_ADDR = 56;
+  static constexpr size_t GUEST_CALL_RET_ADDR = 64;
+  // This frame's stackpoint node (A64StackpointNode), linked through
+  // stackpoint_head in A64BackendContext. The chain has no depth counter or
+  // bound; the node address minus STACKPOINT_PREV is the frame's post-alloc
+  // SP, which is what the longjmp repair restores. (The pending-repair marker
+  // itself stays in A64BackendContext so it can be checked even when native
+  // SP still points at a skipped frame.)
+  static constexpr size_t STACKPOINT_PREV = 72;
+  static constexpr size_t STACKPOINT_GUEST_SP = 80;
+  static constexpr size_t STACKPOINT_GUEST_RET = 84;
 };
 
 }  // namespace a64

--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -280,7 +280,12 @@ bool X64Emitter::Emit(HIRBuilder* builder, EmitFunctionInfo& func_info) {
     const Instr* instr = block->instr_head;
     while (instr) {
       if (synchronize_stack_on_next_instruction_) {
-        if (instr->GetOpcodeNum() != hir::OPCODE_SOURCE_OFFSET) {
+        // Skip annotations as well as SOURCE_OFFSET: under full debug info
+        // the frontend emits COMMENT first, and a check emitted there sits
+        // before the recorded source-map offset, so a longjmp repair would
+        // land past it and it would never run.
+        if (instr->GetOpcodeNum() != hir::OPCODE_SOURCE_OFFSET &&
+            instr->GetOpcodeNum() != hir::OPCODE_COMMENT) {
           synchronize_stack_on_next_instruction_ = false;
           EnsureSynchronizedGuestAndHostStack();
         }
@@ -527,173 +532,169 @@ uint64_t ResolveFunction(void* raw_context, uint64_t target_address) {
         processor->LookupModule(static_cast<uint32_t>(target_address));
 
     if (module_for_address) {
-      XexModule* xexmod = dynamic_cast<XexModule*>(module_for_address);
-      if (xexmod) {
-        InfoCacheFlags* flags = xexmod->GetInstructionAddressFlags(
-            static_cast<uint32_t>(target_address));
-        if (flags) {
-          if (flags->is_return_site) {
-            auto ones_with_address = processor->FindFunctionsWithAddress(
-                static_cast<uint32_t>(target_address));
+      InfoCacheFlags* flags = module_for_address->GetInstructionAddressFlags(
+          static_cast<uint32_t>(target_address));
+      if (flags) {
+        if (flags->is_return_site) {
+          auto ones_with_address = processor->FindFunctionsWithAddress(
+              static_cast<uint32_t>(target_address));
 
-            if (ones_with_address.size() != 0) {
-              // this loop to find a host address for the guest address is
-              // necessary because FindFunctionsWithAddress works via a range
-              // check, but if the function consists of multiple blocks
-              // scattered around with "holes" of instructions that cannot be
-              // reached in between those holes the instructions that cannot be
-              // reached will incorrectly be considered members of the function
+          if (ones_with_address.size() != 0) {
+            // this loop to find a host address for the guest address is
+            // necessary because FindFunctionsWithAddress works via a range
+            // check, but if the function consists of multiple blocks
+            // scattered around with "holes" of instructions that cannot be
+            // reached in between those holes the instructions that cannot be
+            // reached will incorrectly be considered members of the function
 
-              X64Function* candidate = nullptr;
-              uintptr_t host_address = 0;
-              for (auto&& entry : ones_with_address) {
-                X64Function* xfunc = static_cast<X64Function*>(entry);
+            X64Function* candidate = nullptr;
+            uintptr_t host_address = 0;
+            for (auto&& entry : ones_with_address) {
+              X64Function* xfunc = static_cast<X64Function*>(entry);
 
-                host_address = xfunc->MapGuestAddressToMachineCode(
-                    static_cast<uint32_t>(target_address));
-                // host address does exist within the function, and that host
-                // function is not the start of the function, it is instead
-                // somewhere within its existing body
-                // i originally did not have this (xfunc->machine_code() !=
-                // reinterpret_cast<const uint8_t*>(host_address))) condition
-                // here when i distributed builds for testing, no issues arose
-                // related to it but i wanted to be more explicit
-                if (host_address &&
-                    xfunc->machine_code() !=
-                        reinterpret_cast<const uint8_t*>(host_address)) {
-                  candidate = xfunc;
+              host_address = xfunc->MapGuestAddressToMachineCode(
+                  static_cast<uint32_t>(target_address));
+              // host address does exist within the function, and that host
+              // function is not the start of the function, it is instead
+              // somewhere within its existing body
+              // i originally did not have this (xfunc->machine_code() !=
+              // reinterpret_cast<const uint8_t*>(host_address))) condition
+              // here when i distributed builds for testing, no issues arose
+              // related to it but i wanted to be more explicit
+              if (host_address &&
+                  xfunc->machine_code() !=
+                      reinterpret_cast<const uint8_t*>(host_address)) {
+                candidate = xfunc;
+                break;
+              }
+            }
+            // we found an existing X64Function, and a return site within that
+            // function that has a host address w/ native code
+            if (candidate && host_address) {
+              X64Backend* backend =
+                  static_cast<X64Backend*>(processor->backend());
+              // grab the backend context, next we have to check whether the
+              // guest and host stack are out of sync if they arent, its fine
+              // for the backend to create a new function for the guest
+              // address we're resolving if they are, it means that the reason
+              // we're resolving this address is because context is being
+              // restored (probably by longjmp)
+              X64BackendContext* backend_context =
+                  backend->BackendContextForGuestContext(guest_context);
+
+              uint32_t current_stackpoint_index =
+                  backend_context->current_stackpoint_depth;
+
+              --current_stackpoint_index;
+
+              X64BackendStackpoint* stackpoints = backend_context->stackpoints;
+
+              uint32_t current_guest_stackpointer =
+                  static_cast<uint32_t>(guest_context->r[1]);
+              uint32_t num_frames_bigger = 0;
+
+              /*
+                      if the current guest stack pointer is bigger than the
+                 recorded pointer for this stack thats fine, plenty of
+                 functions restore the original stack pointer early
+
+                      if more than 1... we're longjmping and sure of it at
+                 this point (jumping to a return site that has already been
+                 emitted)
+              */
+              while (current_stackpoint_index != 0xFFFFFFFF) {
+                if (current_guest_stackpointer >
+                    stackpoints[current_stackpoint_index].guest_stack_) {
+                  --current_stackpoint_index;
+                  ++num_frames_bigger;
+
+                } else {
                   break;
                 }
               }
-              // we found an existing X64Function, and a return site within that
-              // function that has a host address w/ native code
-              if (candidate && host_address) {
-                X64Backend* backend =
-                    static_cast<X64Backend*>(processor->backend());
-                // grab the backend context, next we have to check whether the
-                // guest and host stack are out of sync if they arent, its fine
-                // for the backend to create a new function for the guest
-                // address we're resolving if they are, it means that the reason
-                // we're resolving this address is because context is being
-                // restored (probably by longjmp)
-                X64BackendContext* backend_context =
-                    backend->BackendContextForGuestContext(guest_context);
+              /*
+                                      DEFINITELY a longjmp, return original
+                 host address. returning the existing host address is going to
+                 set off some extra machinery we have set up to support this
 
-                uint32_t current_stackpoint_index =
-                    backend_context->current_stackpoint_depth;
+                                      to break it down, our caller (us being
+                 this ResolveFunction that this comment is in) is
+                 X64Backend::resolve_function_thunk_ which is implemented in
+                 x64_backend.cc X64HelperEmitter::EmitResolveFunctionThunk, or
+                 a call from the resolver table
 
-                --current_stackpoint_index;
+                                      the x64 fastcall abi dictates that the
+                 stack must always be 16 byte aligned. We select our stack
+                 size for functions to ensure that we keep rsp aligned to 16
+                 bytes
 
-                X64BackendStackpoint* stackpoints =
-                    backend_context->stackpoints;
+                                      but by calling into the body of an
+                 existing function we've pushed our return address onto the
+                 stack (dont worry about this return address, it gets
+                 discarded in a later step)
 
-                uint32_t current_guest_stackpointer =
-                    static_cast<uint32_t>(guest_context->r[1]);
-                uint32_t num_frames_bigger = 0;
+                                      this means that the stack is no longer
+                 16 byte aligned, (rsp % 16) now == 8, and this is the only
+                 time outside of the prolog or epilog of a function that this
+                 will be the case
 
+                                      so, after all direct or indirect
+                 function calls we set
+                 X64Emitter::synchronize_stack_on_next_instruction_ to true.
+                                      On the next instruction that is not
+                 OPCODE_SOURCE_OFFSET we will emit a check when we see
+                 synchronize_stack_on_next_instruction_ is true. We have to
+                 skip OPCODE_SOURCE_OFFSET because its not a "real"
+                 instruction and if we emit on it the return address of the
+                 function call will point to AFTER our check, so itll never be
+                 executed.
+
+                                      our check is just going to do test esp,
+                 15 to see if the stack is misaligned. (using esp instead of
+                 rsp saves 1 byte). We tail emit the handling for when the
+                 check succeeds because in 99.99999% of function calls it will
+                 be aligned, in the end the runtime cost of these checks is 5
+                 bytes for the test instruction which ought to be one cycle
+                 and 5 bytes for the jmp with no cycles taken for the jump
+                 which will be predicted not taken.
+
+                Our handling for the check is implemented in
+                X64HelperEmitter::EmitGuestAndHostSynchronizeStackHelper. we
+                don't call it directly though, instead we go through
+                backend()->synchronize_guest_and_host_stack_helper_for_size(num_bytes_needed_to_represent_stack_size).
+                we place the stack size after the call instruction so we can
+                load it in the helper and readjust the return address to point
+                after the literal value.
+
+                                The helper is going to search the array of
+                stackpoints to find the first one that is greater than or
+                equal to the current stack pointer, when it finds the entry it
+                will set the currently host rsp to the host stack pointer
+                value in the entry, and then subtract the stack size of the
+                caller from that. the current stackpoint index is adjusted to
+                point to the one after the stackpoint we restored to.
+
+                                The helper then jumps back to the function
+                that was longjmp'ed to, with the host stack in its proper
+                state. it just works!
+
+
+
+               */
+
+              if (num_frames_bigger > 1) {
                 /*
-                        if the current guest stack pointer is bigger than the
-                   recorded pointer for this stack thats fine, plenty of
-                   functions restore the original stack pointer early
-
-                        if more than 1... we're longjmping and sure of it at
-                   this point (jumping to a return site that has already been
-                   emitted)
-                */
-                while (current_stackpoint_index != 0xFFFFFFFF) {
-                  if (current_guest_stackpointer >
-                      stackpoints[current_stackpoint_index].guest_stack_) {
-                    --current_stackpoint_index;
-                    ++num_frames_bigger;
-
-                  } else {
-                    break;
-                  }
-                }
-                /*
-                                        DEFINITELY a longjmp, return original
-                   host address. returning the existing host address is going to
-                   set off some extra machinery we have set up to support this
-
-                                        to break it down, our caller (us being
-                   this ResolveFunction that this comment is in) is
-                   X64Backend::resolve_function_thunk_ which is implemented in
-                   x64_backend.cc X64HelperEmitter::EmitResolveFunctionThunk, or
-                   a call from the resolver table
-
-                                        the x64 fastcall abi dictates that the
-                   stack must always be 16 byte aligned. We select our stack
-                   size for functions to ensure that we keep rsp aligned to 16
-                   bytes
-
-                                        but by calling into the body of an
-                   existing function we've pushed our return address onto the
-                   stack (dont worry about this return address, it gets
-                   discarded in a later step)
-
-                                        this means that the stack is no longer
-                   16 byte aligned, (rsp % 16) now == 8, and this is the only
-                   time outside of the prolog or epilog of a function that this
-                   will be the case
-
-                                        so, after all direct or indirect
-                   function calls we set
-                   X64Emitter::synchronize_stack_on_next_instruction_ to true.
-                                        On the next instruction that is not
-                   OPCODE_SOURCE_OFFSET we will emit a check when we see
-                   synchronize_stack_on_next_instruction_ is true. We have to
-                   skip OPCODE_SOURCE_OFFSET because its not a "real"
-                   instruction and if we emit on it the return address of the
-                   function call will point to AFTER our check, so itll never be
-                   executed.
-
-                                        our check is just going to do test esp,
-                   15 to see if the stack is misaligned. (using esp instead of
-                   rsp saves 1 byte). We tail emit the handling for when the
-                   check succeeds because in 99.99999% of function calls it will
-                   be aligned, in the end the runtime cost of these checks is 5
-                   bytes for the test instruction which ought to be one cycle
-                   and 5 bytes for the jmp with no cycles taken for the jump
-                   which will be predicted not taken.
-
-                  Our handling for the check is implemented in
-                  X64HelperEmitter::EmitGuestAndHostSynchronizeStackHelper. we
-                  don't call it directly though, instead we go through
-                  backend()->synchronize_guest_and_host_stack_helper_for_size(num_bytes_needed_to_represent_stack_size).
-                  we place the stack size after the call instruction so we can
-                  load it in the helper and readjust the return address to point
-                  after the literal value.
-
-                                  The helper is going to search the array of
-                  stackpoints to find the first one that is greater than or
-                  equal to the current stack pointer, when it finds the entry it
-                  will set the currently host rsp to the host stack pointer
-                  value in the entry, and then subtract the stack size of the
-                  caller from that. the current stackpoint index is adjusted to
-                  point to the one after the stackpoint we restored to.
-
-                                  The helper then jumps back to the function
-                  that was longjmp'ed to, with the host stack in its proper
-                  state. it just works!
-
-
-
+                 * can't do anything about this right now :(
+                 * epic mickey is quite slow due to having to call resolve on
+                 * every longjmp, and it longjmps a lot but if we add an
+                 * indirection we lose our stack misalignment check
                  */
+                /* reinterpret_cast<X64CodeCache*>(backend->code_cache())
+    ->AddIndirection(static_cast<uint32_t>(target_address),
+                     static_cast<uint32_t>(host_address));
+                      */
 
-                if (num_frames_bigger > 1) {
-                  /*
-                   * can't do anything about this right now :(
-                   * epic mickey is quite slow due to having to call resolve on
-                   * every longjmp, and it longjmps a lot but if we add an
-                   * indirection we lose our stack misalignment check
-                   */
-                  /* reinterpret_cast<X64CodeCache*>(backend->code_cache())
-      ->AddIndirection(static_cast<uint32_t>(target_address),
-                       static_cast<uint32_t>(host_address));
-                        */
-
-                  return host_address;
-                }
+                return host_address;
               }
             }
           }
@@ -1022,6 +1023,11 @@ void X64Emitter::CallNative(uint64_t (*fn)(void* raw_context, uint64_t arg0),
 }
 
 void X64Emitter::CallNativeSafe(void* fn) {
+  // The guest-to-host thunk's tail restores mxcsr_fpu, so any tracked VMX
+  // mode is stale after this returns. (Tracker-only; when this runs inside
+  // a tail lambda the function's emission is already complete and the write
+  // is inert.)
+  ForgetMxcsrMode();
   // rcx = target function
   // rdx = arg0
   // r8  = arg1
@@ -2065,6 +2071,11 @@ bool X64Emitter::ChangeMxcsrMode(MXCSRMode new_mode, bool already_set) {
         SetMxcsrModeFlags(*this, new_mode);
       }
       return true;
+    } else {
+      // Even with the register already set, the backend flags word must
+      // describe the new mode, or a later dynamic check reads a stale flag
+      // (reachable through SET_ROUNDING_MODE).
+      SetMxcsrModeFlags(*this, new_mode);
     }
   }
   return false;

--- a/src/xenia/cpu/backend/x64/x64_seq_control.cc
+++ b/src/xenia/cpu/backend/x64/x64_seq_control.cc
@@ -203,6 +203,11 @@ struct TRAP_TRUE_I8
     e.test(i.src1, i.src1);
     e.jnz(dotrap, X64Emitter::T_NEAR);
     e.L(after);
+    // The trap path came back through the guest-to-host thunk with the FPU
+    // image live; the fall-through kept the entry mode. Meet to Unknown so
+    // the next float op re-checks. Only the I8 form needs this: the PPC
+    // frontend always builds the trap condition from I8 compare results.
+    e.ForgetMxcsrMode();
   }
 };
 struct TRAP_TRUE_I16

--- a/src/xenia/cpu/module.h
+++ b/src/xenia/cpu/module.h
@@ -10,6 +10,8 @@
 #ifndef XENIA_CPU_MODULE_H_
 #define XENIA_CPU_MODULE_H_
 
+#include <atomic>
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <string>
@@ -26,6 +28,28 @@ namespace cpu {
 
 class Processor;
 
+struct InfoCacheFlags {
+  uint32_t was_resolved : 1;  // has this address ever been called/requested
+                              // via resolvefunction?
+  uint32_t accessed_mmio : 1;
+  uint32_t is_syscall_func : 1;
+  uint32_t is_return_site : 1;  // address can be reached from another function
+                                // by returning
+  uint32_t reserved : 28;
+};
+static_assert(sizeof(InfoCacheFlags) == 4,
+              "InfoCacheFlags size should be equal to sizeof ppc instruction.");
+
+// Each slot is one 32-bit word (XexModule's shared info-cache mmap, or
+// RawModule's vector) written by several threads. Set bits atomically so
+// concurrent writes don't lose updates.
+inline void AtomicSetInfoCacheFlags(InfoCacheFlags* slot, InfoCacheFlags bits) {
+  uint32_t mask;
+  std::memcpy(&mask, &bits, sizeof(mask));
+  std::atomic_ref<uint32_t>(*reinterpret_cast<uint32_t*>(slot))
+      .fetch_or(mask, std::memory_order_relaxed);
+}
+
 class Module {
  public:
   explicit Module(Processor* processor);
@@ -37,6 +61,14 @@ class Module {
   virtual bool is_executable() const = 0;
 
   virtual bool ContainsAddress(uint32_t address);
+
+  // Per-instruction flag slot for |guest_address|, or null when the module
+  // keeps no instruction metadata for it. XexModule backs this with its
+  // shared info cache; RawModule with a plain vector so the longjmp repair
+  // path works under the test harness too.
+  virtual InfoCacheFlags* GetInstructionAddressFlags(uint32_t guest_address) {
+    return nullptr;
+  }
 
   Symbol* LookupSymbol(uint32_t address, bool wait = true);
   virtual Symbol::Status DeclareFunction(uint32_t address,

--- a/src/xenia/cpu/ppc/ppc_hir_builder.cc
+++ b/src/xenia/cpu/ppc/ppc_hir_builder.cc
@@ -27,7 +27,6 @@
 #include "xenia/cpu/ppc/ppc_frontend.h"
 #include "xenia/cpu/ppc/ppc_opcode_info.h"
 #include "xenia/cpu/processor.h"
-#include "xenia/cpu/xex_module.h"
 DEFINE_bool(
     break_on_unimplemented_instructions, true,
     "Break to the host debugger (or crash if no debugger attached) if an "
@@ -516,9 +515,11 @@ static Value* FpIsSignalingNan(PPCHIRBuilder& f, Value* value) {
                                f.LoadConstantUint64(0x0008000000000000ull))));
 }
 
-// VXSNAN is unconditional on PPC, and the host cannot be relied on for it: the
-// a64 sequences branch around the arithmetic when an operand is a NaN, so a
-// signalling operand may never reach an instruction that would signal.
+// VXSNAN is unconditional on PPC, and the host cannot be relied on for it:
+// several sequences still branch around the arithmetic when an operand is a
+// NaN (and result-gated ones clear host status per Rc instruction anyway),
+// so a signalling operand may never reach an instruction that would signal.
+// This software term is load-bearing even where the hardware op now runs.
 Value* PPCHIRBuilder::FpInvalidFromOperands(
     std::initializer_list<Value*> operands) {
   Value* any_snan = nullptr;
@@ -780,14 +781,11 @@ void PPCHIRBuilder::SetReturnAddress(Value* value) {
   Module* mod = this->function_->module();
   if (value && value->IsConstant()) {
     if (mod) {
-      XexModule* xexmod = dynamic_cast<XexModule*>(mod);
-      if (xexmod) {
-        auto flags = xexmod->GetInstructionAddressFlags(value->AsUint32());
-        if (flags) {
-          InfoCacheFlags bits{};
-          bits.is_return_site = true;
-          AtomicSetInfoCacheFlags(flags, bits);
-        }
+      auto flags = mod->GetInstructionAddressFlags(value->AsUint32());
+      if (flags) {
+        InfoCacheFlags bits{};
+        bits.is_return_site = true;
+        AtomicSetInfoCacheFlags(flags, bits);
       }
     }
   }

--- a/src/xenia/cpu/ppc/testing/instr_seq_njm.s
+++ b/src/xenia/cpu/ppc/testing/instr_seq_njm.s
@@ -1,0 +1,35 @@
+# VSCR.NJ (non-Java mode) regression: NJ=1 (the 360 default) flushes vector
+# FP denormal inputs to signed zero; NJ=0 preserves them. mtvscr's extract
+# reads NJ from bit 16 of word 3 of VB. Exercises SET_NJM's mode-variant
+# switching on both backends, which no other suite covers.
+test_njm_off_preserves_denormals:
+  #_ REGISTER_IN v4 [00000001, 00000001, 00000001, 00000001]
+  #_ REGISTER_IN v5 [00000000, 00000000, 00000000, 00000000]
+  #_ REGISTER_IN v6 [00000000, 00000000, 00000000, 00000000]
+  mtvscr v6
+  vaddfp v7, v4, v5
+  blr
+  #_ REGISTER_OUT v7 [00000001, 00000001, 00000001, 00000001]
+
+test_njm_on_flushes_denormals:
+  #_ REGISTER_IN v4 [00000001, 00000001, 00000001, 00000001]
+  #_ REGISTER_IN v5 [00000000, 00000000, 00000000, 00000000]
+  #_ REGISTER_IN v6 [00000000, 00000000, 00000000, 00010000]
+  mtvscr v6
+  vaddfp v7, v4, v5
+  blr
+  #_ REGISTER_OUT v7 [00000000, 00000000, 00000000, 00000000]
+
+test_njm_flip_and_back:
+  #_ REGISTER_IN v4 [80000001, 80000001, 80000001, 80000001]
+  #_ REGISTER_IN v5 [00000000, 00000000, 00000000, 00000000]
+  #_ REGISTER_IN v6 [00000000, 00000000, 00000000, 00000000]
+  #_ REGISTER_IN v8 [00000000, 00000000, 00000000, 00010000]
+  mtvscr v6
+  vaddfp v7, v4, v5
+  mtvscr v8
+  vaddfp v9, v4, v5
+  blr
+  #_ REGISTER_OUT v7 [80000001, 80000001, 80000001, 80000001]
+  # NJ=1 flushes the -denormal input to -0, and IEEE (-0) + (+0) = +0.
+  #_ REGISTER_OUT v9 [00000000, 00000000, 00000000, 00000000]

--- a/src/xenia/cpu/ppc/testing/instr_seq_stacksync.s
+++ b/src/xenia/cpu/ppc/testing/instr_seq_stacksync.s
@@ -1,0 +1,51 @@
+# Longjmp repair regression: a guest control transfer that skips two live
+# frames must be caught by the resolve-time stackpoint walk and repaired by
+# the sync helper. Shape: T0 -> T -> W -> E -> L; T saves LR/r1 setjmp-style
+# BEFORE its stwu (so the walk breaks at T's own node, where both backends'
+# SP-restore arithmetic provably coincides), and L longjmps to T's return
+# site. L's blr tail-pops its own node, leaving E and W skipped (= 2 > 1).
+test_stacksync_longjmp_repair:
+  #_ REGISTER_IN r1 0x1000F000
+  #_ REGISTER_IN r20 0
+  #_ REGISTER_IN r21 0
+  mfspr r12, lr
+  stwu r1, -0x60(r1)
+  bl lj_t
+lj_t0_ret:
+  addi r21, r21, 100
+  addi r1, r1, 0x60
+  mtspr lr, r12
+  blr
+lj_t:
+  mfspr r13, lr
+  bl lj_t_anchor
+lj_t_anchor:
+  mfspr r17, lr
+  addi r17, r17, 20
+  or r16, r1, r1
+  stwu r1, -0x40(r1)
+  bl lj_w
+lj_t_ret:
+  addi r20, r20, 0x41
+  mtspr lr, r13
+  blr
+lj_w:
+  addi r21, r21, 1
+  stwu r1, -0x30(r1)
+  bl lj_e
+  addi r1, r1, 0x30
+  blr
+lj_e:
+  addi r21, r21, 1
+  stwu r1, -0x30(r1)
+  bl lj_l
+  addi r1, r1, 0x30
+  blr
+lj_l:
+  addi r21, r21, 1
+  mtspr lr, r17
+  or r1, r16, r16
+  blr
+  #_ REGISTER_OUT r1 0x1000F000
+  #_ REGISTER_OUT r20 0x41
+  #_ REGISTER_OUT r21 103

--- a/src/xenia/cpu/raw_module.cc
+++ b/src/xenia/cpu/raw_module.cc
@@ -55,6 +55,8 @@ bool RawModule::LoadFile(uint32_t base_address,
 
   // Notify backend about executable code.
   processor_->backend()->CommitExecutableRange(low_address_, high_address_);
+  instruction_flags_.assign((high_address_ - low_address_ + 3) / 4,
+                            InfoCacheFlags{});
   return true;
 }
 
@@ -74,6 +76,14 @@ bool RawModule::ContainsAddress(uint32_t address) {
 std::unique_ptr<Function> RawModule::CreateFunction(uint32_t address) {
   return std::unique_ptr<Function>(
       processor_->backend()->CreateGuestFunction(this, address));
+}
+
+InfoCacheFlags* RawModule::GetInstructionAddressFlags(uint32_t guest_address) {
+  if (instruction_flags_.empty() || guest_address < low_address_ ||
+      guest_address >= high_address_) {
+    return nullptr;
+  }
+  return &instruction_flags_[(guest_address - low_address_) / 4];
 }
 
 }  // namespace cpu

--- a/src/xenia/cpu/raw_module.h
+++ b/src/xenia/cpu/raw_module.h
@@ -11,6 +11,7 @@
 #define XENIA_CPU_RAW_MODULE_H_
 
 #include <string>
+#include <vector>
 
 #include "xenia/cpu/module.h"
 
@@ -28,6 +29,8 @@ class RawModule : public Module {
   // in it.
   void SetAddressRange(uint32_t base_address, uint32_t size);
 
+  InfoCacheFlags* GetInstructionAddressFlags(uint32_t guest_address) override;
+
   const std::string& name() const override { return name_; }
   bool is_executable() const override { return is_executable_; }
   void set_name(const std::string_view name) { name_ = name; }
@@ -44,6 +47,9 @@ class RawModule : public Module {
   uint32_t base_address_;
   uint32_t low_address_;
   uint32_t high_address_;
+  // One slot per instruction, sized on load; empty when the module was set
+  // up via SetAddressRange without a file (the accessor then returns null).
+  std::vector<InfoCacheFlags> instruction_flags_;
 };
 
 }  // namespace cpu

--- a/src/xenia/cpu/xex_module.h
+++ b/src/xenia/cpu/xex_module.h
@@ -37,27 +37,6 @@ constexpr fourcc_t kElfSignature = make_fourcc(0x7F, 'E', 'L', 'F');
 constexpr fourcc_t kXBESignature = make_fourcc("XBEH");
 
 class Runtime;
-struct InfoCacheFlags {
-  uint32_t was_resolved : 1;  // has this address ever been called/requested
-                              // via resolvefunction?
-  uint32_t accessed_mmio : 1;
-  uint32_t is_syscall_func : 1;
-  uint32_t is_return_site : 1;  // address can be reached from another function
-                                // by returning
-  uint32_t reserved : 28;
-};
-static_assert(sizeof(InfoCacheFlags) == 4,
-              "InfoCacheFlags size should be equal to sizeof ppc instruction.");
-
-// The flags share one 32-bit word in a shared mmap and are written by several
-// threads. Set bits atomically so concurrent writes don't lose updates.
-inline void AtomicSetInfoCacheFlags(InfoCacheFlags* slot, InfoCacheFlags bits) {
-  uint32_t mask;
-  std::memcpy(&mask, &bits, sizeof(mask));
-  std::atomic_ref<uint32_t>(*reinterpret_cast<uint32_t*>(slot))
-      .fetch_or(mask, std::memory_order_relaxed);
-}
-
 struct XexInfoCache {
   // increment this to invalidate all user infocaches
   static constexpr uint32_t CURRENT_INFOCACHE_VERSION = 4;
@@ -250,7 +229,7 @@ class XexModule : public xe::cpu::Module {
              XEX_MODULE_PATCH_FULL));
   }
 
-  InfoCacheFlags* GetInstructionAddressFlags(uint32_t guest_addr);
+  InfoCacheFlags* GetInstructionAddressFlags(uint32_t guest_addr) override;
 
   virtual void Precompile() override;
 


### PR DESCRIPTION
Four a64 code-generation changes that build on one another and are
verified as one tree: in-frame stackpoints and cheaper call machinery;
NZCV fusion and shorter vector sequences; FPCR mode tracking across
blocks and host transitions; and result-gated NaN and denormal fixups
placed in the function tail. Each section below is self-contained.

1. Stackpoints and call machinery

Each guest frame now carries its own stackpoint record instead of an
entry in a per-context array. A64StackpointNode {prev_, guest r1, guest
lr} lives at sp+0x48 of the frame and is linked through
A64BackendContext::stackpoint_head. The prolog saves x0/x30 with one
stp, zeroes the call-return slot and stores prev_ with a second stp,
stores the two guest words with a third, then publishes the head; all
node fields are written before the head store so an async signal never
sees a head pointing at an uninitialised node. PopStackpoint reloads
prev_ from the frame before teardown at every pop site. The node's own
address identifies the frame: node - STACKPOINT_PREV is the frame's
post-alloc SP, which is what the longjmp repair restores.

ResolveFunction's longjmp detection (FindStackpointSyncNode) walks the
chain newest-first with the same rule as before (more than one live
frame skipped by guest r1 means a real longjmp) and hands the node to
the synchronize helper, which validates it (non-null, 8 mod 16, above
live SP), publishes head before moving SP, then sets SP from the node.

Behaviour changes a maintainer must know:
- The frame grows from 80 to 96 bytes (+16 B host stack per guest
  frame, no extra instructions).
- cvar a64_max_stackpoints is removed. There is no depth counter and
  no bound: runaway recursion now hits the host stack guard page
  instead of the counted FatalError. DeinitializeBackendContext no
  longer frees anything; PrepareForReentry just drops the chain.
- Module::GetInstructionAddressFlags is now virtual, with
  InfoCacheFlags and AtomicSetInfoCacheFlags moved to module.h.
  XexModule backs it with its info cache as before; RawModule backs it
  with a plain vector, so is_return_site marking and the repair path
  also work under the PPC test harness. Callers no longer dynamic_cast
  to XexModule.
- Both backends skip OPCODE_COMMENT as well as OPCODE_SOURCE_OFFSET
  when arming the post-call stack check: under full debug info the
  frontend emits COMMENT first, so a check placed there sat before the
  recorded source-map offset and a repair landing at the offset would
  skip it.
- Adds src/xenia/cpu/ppc/testing/instr_seq_stacksync.s.

Relation to d5956d7e3 (upstream #177): the resolve-time contract is
unchanged (is_return_site flags, repair marker checked at the return
site); only the array plus depth counter is replaced by the in-frame
linked node.

Call machinery. CALL_INDIRECT's encoded-mode constants
(indirection_table_bias, code_execute_base,
external_indirection_table) and both guest-to-host thunk addresses are
stored in A64BackendContext and loaded with one ldr each; Call and
CallIndirect share EmitEncodedIndirectionLookup. The cold external
target case moves to the tail via tbnz when the function is small
enough to prove the +/-32 KiB reach (near_tbz_branches_safe_), and
branches to the epilog and the preempt yield use the single-instruction
form when the +/-1 MiB reach is provable (near_tail_branches_safe_,
computed once per function from the HIR instruction count at 256 B per
instruction, which also covers the literal-pool islands). Tail calls
through the indirection table hoist the x0/x30 reload above the return
check.

Host transitions. Both thunks now read FPCR back and skip the
context-synchronizing msr when it already equals fpcr_fpu. CallExtern
uses a new thunk without the 28 Q-register save/restore. That relies
on no HIR value being live in q4-q31 across a CALL, which is a property
of HIR construction (guest-to-guest calls are a bare blr into a callee
that uses q4-q31 freely; ContextPromotionPass stops at the first
volatile instruction), not something the register allocator enforces:
a pass that hoists a value across a CALL would break it. CallNativeSafe,
which is emitted inside sequences with operands in flight, keeps the
full thunk.

2. NZCV fusion, indirect-call forwarding and vector sequences

NZCV fusion between adjacent HIR instructions. AND_I8/I32/I64 emit ANDS
instead of AND and declare that NZCV now holds a zero test of dest
(condition NE). The emit loop shifts that declaration from "fresh" to
"armed" after every SelectSequence, so exactly the next sequence can
consume it and nothing later; it is reset at every block entry and
after the stack-synchronize helper call, which clobbers NZCV. Consumers
are COMPARE_EQ/NE against constant zero (cset on the held flags) and
SELECT_I8..F64 (the cmp is dropped and the select picks on the held
condition). A producer may declare any condition that is true exactly
when the register is nonzero; in this commit only NE is declared. The
I8 case relies on I8 values being zero-extended in their W registers,
which the backend already assumes.

The same fresh/armed handoff forwards an indirect-call target:
LOAD_CONTEXT_I64 whose single use is the immediately following
CALL_INDIRECT or CALL_INDIRECT_TRUE loads w16 directly and skips the
allocated destination, since the call contract reads the target from
w16 anyway.

Vector sequences:
- PERMUTE by int8: PPC byte order is handled by rev32 of the two
  tables instead of XORing the control with 3, and the rev32 doubles as
  the copy into v0/v1 (register controls go from 7 to 5 instructions).
  The vmrghb/vmrglb controls become zip1/zip2 plus rev32, which is the
  same instruction count as the TBL form but saves the control-vector
  literal load.
- PERMUTE by int16 (vmrghh/vmrglh): zip plus rev64.4s, 2 instructions
  instead of 4. PERMUTE_I32 vmrghw/vmrglw: a single zip1/zip2 instead
  of 4.
- VECTOR_SHL/SHR/SHA with a constant amount vector: uniform amounts use
  the immediate-form shift; non-uniform amounts are masked (and negated
  for right shifts) on the host so one register-form shift remains.
- SELECT_V128 with dest aliasing a data operand uses BIF/BIT instead of
  copying through v0.
- Scalar SHL/SHR/SHA/ROTATE_LEFT with a register amount and a register
  src1 drop the staging copy: LSLV/LSRV/ASRV/RORV read both sources
  before writing dest. The constant-src1 shape is unchanged.

Behaviour change a maintainer must know: MAX/MIN_F32/F64 with both
operands constant previously materialised only src1 and read whatever
the previous sequence had left in s1/d1; the second constant is now
loaded too.

3. FPCR mode tracking

The emitter keeps a static FPCR mode so that consecutive VMX ops share
one msr. This commit makes that tracker correct at every place the
runtime mode can differ from the tracked one, and lets it survive block
boundaries instead of resetting at each block head.

Contract. The lattice is {Unknown, Fpu, Vmx, VmxDaz} with
meet(a, b) = a if a == b else Unknown. Every guest function is entered
in Fpu: the host-to-guest thunk restores fpcr_fpu on entry, every call
site runs EnsureFpuFpcrModeForTransition before the call, every callee
returns in Fpu, the guest-to-host thunks restore fpcr_fpu after host
callbacks and the resolve thunk now restores it after the host resolve.
Within a function a pre-scan of the final HIR counts each block's
expected predecessor edges (branches can sit mid-block, so every
instruction is scanned, plus a fall-through edge unless the block ends
in an unconditional BRANCH, plus the function entry edge on the first
block). During emission every branch records the tracker's mode at the
branch point on its target, block ends record the fall-through mode,
and the entry records Fpu. A block is seeded with the meet only when
its recorded count equals the expected count; a loop back edge has not
been emitted when its header is reached, so loop headers, including a
first block that is a loop header, start Unknown. Transitions switch
to Fpu when a VMX mode is tracked, or when the tracker is Unknown in a
function that touches VEC128 at all, and assume Fpu on return.
Conditional regions (TRAP_TRUE, CALL_TRUE, CALL_INDIRECT_TRUE and the
inline-MMIO arm of CallNativeSafe) meet the post-call state with the
entry state. RETURN/RETURN_TRUE do not participate and the epilog has
no guard; PPC blr lowers to CALL_INDIRECT, so they are unreachable from
the frontend today. ForgetFpcrMode remains only for SET_NJM, which
rewrites the VMX FPCR images.

Behaviour changes a maintainer must know:
- Scalar sequences whose result depends on FPCR (MAX/MIN, CONVERT,
  ROUND, IS_NAN, the float compares, RSQRT_F64) now switch to Fpu
  explicitly; before they ran in whatever mode the last vector op left.
- CallNativeSafe emits the transition guard itself, so the inline MMIO
  fallback and the tracers no longer reach host code in a VMX mode.
- The preempt yield tail switches to Fpu before the host call in
  functions that touch VEC128 and re-establishes the mode the hot path
  holds afterwards (ReloadFpcrMode); a null yield handler takes the
  same restore path.
- The resolve thunk restores fpcr_fpu before jumping to the resolved
  function.
- x64: CallNativeSafe and TRAP_TRUE_I8 forget the MXCSR mode for the
  same reason, and ChangeMxcsrMode updates the backend flags word on
  the already_set path so SET_ROUNDING_MODE leaves it consistent.

4. NaN and denormal fixups off the hot path

Scalar NaN handling. EmitFpBinOpWithPpcNan_F32/F64 and
EmitFmaWithPpcNan_F32/F64 are now result-gated: the hardware op runs
first and a single fcmp on the result decides whether the positional
PPC NaN walk is needed, since any NaN input propagates to a NaN result.
The walk (first NaN by operand position, quieted) sits in the function
tail when near_tail_branches_safe() holds and inline behind a
branch-over otherwise. When dest aliases a source the original value is
preserved in scratch before the op. NaN results are never canonicalised
(with FPCR.DN clear the hardware default QNaN is PPC's; the invariant
is stated once at DEFAULT_FPU_FPCR) and never negated: every NaN takes
the branch, so the fneg for the negated forms runs only on numeric
results and all cold-path exits rejoin below it.

Vector FMA. FixupVmxNan_V128_Fma is gated by a four-instruction result
test (fcmeq, uminv, fmov, cbz) with the ten-instruction fixup in the
tail. On hosts where FPCR.FZ flushes inputs the allocated sources feed
the FMA and the fixup directly instead of being copied to v0/v1/v3;
PickFmaFixupScratch chooses the fixup's scratch so it never aliases a
live source. Without the near_tail_branches_safe() gating, any function
past roughly 3000 HIR instructions containing vmaddfp would fail to
assemble because the tail would fall outside cbz's reach.

Software denormal flushes. FlushDenormals_V128 and the FMA input
flushes are gated at runtime on VSCR.NJ through the backend flags word
(one ldr plus tbz around each flush block, threshold loaded once per
block), so with NJ clear denormals pass through as on hardware. Hosts
whose FZ flushes inputs never emit these blocks. With
accurate_vmx_denormal_flush the FMA input flush is pinned on while the
output flush stays NJ-gated; that is harmless because the VmxDaz FPCR
flushes outputs in hardware.

PACK. D3DCOLOR, SHORT_2, SHORT_4 and the FLOAT16 forms quiet a
signalling NaN (fmaxnm x, x) before the clamp, so an SNaN packs the
same way as on x64, where MAXPS/MINPS return the second operand for any
NaN.

Frontend. The comment on PPCHIRBuilder::FpInvalidFromOperands now says
why the software VXSNAN term stays load-bearing with result-gated
sequences. Adds src/xenia/cpu/ppc/testing/instr_seq_njm.s.

Evidence: PPC corpus gate 169,048/169,048 passing (the base corpus plus
the new instr_seq_stacksync.s and instr_seq_njm.s suites). Corpus
dynamic host instruction count 9,104,539 -> 7,900,209 (-13.2%) from the
call machinery, a further -3.3% from FPCR tracking; emitted size: fmadds
460 -> 408 B, vperm 192 -> 184 B, the vmaddfp site 184 -> 124 B, the
fmadd hot path 27 -> 3 instructions, fadd 4 -> 3; cross-backend
agreement on the NaN test set. The thunk changes are covered by the gate
only. There is no runtime measurement.