### PR TITLE
[UI] Call XInitThreads before wxEntry on Linux

### DIFF
--- a/src/xenia/ui/windowed_app_main_linux.cc
+++ b/src/xenia/ui/windowed_app_main_linux.cc
@@ -12,6 +12,7 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include <X11/Xlib.h>
 #include <wx/wx.h>
 
 #include "xenia/base/platform.h"
@@ -44,6 +45,8 @@ int main(int argc, char** argv) {
   if (!secure_getenv("GDK_BACKEND")) {
     setenv("GDK_BACKEND", "x11", 1);
   }
+
+  XInitThreads();
 
   xe::ui::g_argc = argc;
   xe::ui::g_argv = argv;


### PR DESCRIPTION
The Linux entry point pins GTK to the X11 backend but never makes Xlib thread safe. Mesa's Vulkan X11 WSI runs a present queue thread that issues xcb requests on the same display connection, so Xlib calls from the UI thread race it and abort with `xcb_io.c poll_for_event: Assertion !xcb_xlib_threads_sequence_lost`.

Reproduced on every title launch on Fedora 44 aarch64 (Ayaneo Pocket DS, Turnip under Xwayland). With this change the same setup launches reliably.
